### PR TITLE
Remove Windows static libraries because they are too big

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -21,38 +21,5 @@ nmake
 if errorlevel 1 exit 1
 nmake check
 if errorlevel 1 exit 1
-
-cd ..
-if errorlevel 1 exit 1
-
-mkdir build-static
-if errorlevel 1 exit 1
-cd build-static
-if errorlevel 1 exit 1
-
-:: Build static libraries and copy manually
-cmake -G "NMake Makefiles" ^
-         -DCMAKE_BUILD_TYPE=Release ^
-         -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
-         -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-         -DCMAKE_RELEASE_POSTFIX="_static" ^
-         -Dprotobuf_WITH_ZLIB=ON ^
-         -Dprotobuf_BUILD_SHARED_LIBS=OFF ^
-         -Dprotobuf_MSVC_STATIC_RUNTIME=OFF ^
-         ..
-if errorlevel 1 exit 1
-
-nmake
-if errorlevel 1 exit 1
-
-nmake install
-if errorlevel 1 exit 1
-
-ren "%LIBRARY_BIN%\protoc.exe" protoc_static.exe
-if errorlevel 1 exit 1
-
-@rem now install the shared libraries
-cd ..\build-shared
-if errorlevel 1 exit 1
 nmake install
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     folder: third_party/googletest
 
 build:
-  number: 0
+  number: 1
   # Requires C++ 11, VS 2008 is not supported
   skip: True  # [win and vc<14]
   run_exports:
@@ -52,9 +52,6 @@ test:
     - if not exist %PREFIX%\\Library\\lib\\libprotoc.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\libprotobuf.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\libprotobuf-lite.lib exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\libprotoc_static.lib exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\libprotobuf_static.lib exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\libprotobuf-lite_static.lib exit 1  # [win]
 
 about:
   home: https://developers.google.com/protocol-buffers/


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
