### PR TITLE
Add patch to workaround missing marco definition

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,11 +1,15 @@
 c_compiler:
 - gcc
+c_compiler_version:
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
 - gxx
+cxx_compiler_version:
+- '7'
 docker_image:
 - condaforge/linux-anvil-comp7
 pin_run_as_build:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -2,12 +2,16 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 c_compiler:
 - clang
+c_compiler_version:
+- '4'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
 - clangxx
+cxx_compiler_version:
+- '4'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/recipe/.circleci/checkout_merge_commit.sh
+++ b/recipe/.circleci/checkout_merge_commit.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+
+# Update PR refs for testing.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/head:pr/${CIRCLE_PR_NUMBER}/head"
+    FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/merge:pr/${CIRCLE_PR_NUMBER}/merge"
+fi
+
+# Retrieve the refs.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git fetch -u origin ${FETCH_REFS}
+fi
+
+# Checkout the PR merge ref.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git checkout -qf "pr/${CIRCLE_PR_NUMBER}/merge"
+fi
+
+# Check for merge conflicts.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git branch --merged | grep "pr/${CIRCLE_PR_NUMBER}/head" > /dev/null
+fi

--- a/recipe/.gitattributes
+++ b/recipe/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+
+*.patch binary
+*.diff binary
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/recipe/.github/CONTRIBUTING.md
+++ b/recipe/.github/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+Thanks for your interest in helping out conda-forge.
+
+Whether you are brand new or a seasoned maintainer, we always appreciate
+feedback from the community about how we can improve conda-forge. If you
+are submitting a PR or issue, please fill out the respective template. Should
+any questions arise please feel free to ask the maintainer team of the
+respective feedstock or reach out to `@conda-forge/core` for more complex
+issues.
+
+In the case of any issues reported, please be sure to demonstrate the relevant
+issue (even if it is an absence of a feature). Providing this information will
+help busy maintainers understand what it is you hope to accomplish. Also this
+will help provide them clues as to what might be going wrong. These examples
+can also be reused as tests in the build to ensure further packages meet these
+criteria. This is requested to help you get timely and relevant feedback. :)

--- a/recipe/.github/ISSUE_TEMPLATE.md
+++ b/recipe/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+Thanks for reporting your issue.
+Please fill out the sections below.
+-->
+Issue:
+
+<br/>
+Environment (<code>conda list</code>):
+<details>
+
+```
+$ conda list
+
+```
+</details>
+
+<br/>
+Details about  <code>conda</code> and system ( <code>conda info</code> ):
+<details>
+
+```
+$ conda info
+
+```
+</details>

--- a/recipe/.github/PULL_REQUEST_TEMPLATE.md
+++ b/recipe/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+Thank you for pull request.
+Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
+-->
+Checklist
+* [ ] Used a fork of the feedstock to propose changes
+* [ ] Bumped the build number (if the version is unchanged)
+* [ ] Reset the build number to `0` (if the version changed)
+* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
+* [ ] Ensured the license file is being packaged.
+
+<!--
+Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
+-->
+
+<!--
+Please add any other relevant info below:
+-->

--- a/recipe/.gitignore
+++ b/recipe/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+
+build_artifacts

--- a/recipe/5881.patch
+++ b/recipe/5881.patch
@@ -1,0 +1,85 @@
+From 3062f297078fb9a51001ba83971277a8bd1497ef Mon Sep 17 00:00:00 2001
+From: Bo Yang <teboring@google.com>
+Date: Wed, 13 Mar 2019 05:29:04 +0000
+Subject: [PATCH 1/3] Fix macros in header of generated code
+
+* Define PROTOBUF_MIN_PROTOC_VERSION in port_def.inc
+* Remove duplicated GOOGLE_PROTOBUF_MIN_LIBRARY_VERSION from common.h
+---
+ src/google/protobuf/port_def.inc   | 1 +
+ src/google/protobuf/stubs/common.h | 4 ----
+ 2 files changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/src/google/protobuf/port_def.inc b/src/google/protobuf/port_def.inc
+index 9a6fc8c83f..278dd5c3d7 100644
+--- a/src/google/protobuf/port_def.inc
++++ b/src/google/protobuf/port_def.inc
+@@ -257,6 +257,7 @@
+ 
+ #define PROTOBUF_VERSION 3007000
+ #define PROTOBUF_MIN_HEADER_VERSION_FOR_PROTOC 3007000
++#define PROTOBUF_MIN_PROTOC_VERSION 3007000
+ #define PROTOBUF_VERSION_SUFFIX ""
+ 
+ // The minimum library version which works with the current version of the
+diff --git a/src/google/protobuf/stubs/common.h b/src/google/protobuf/stubs/common.h
+index 43da789f26..0b469c69c6 100644
+--- a/src/google/protobuf/stubs/common.h
++++ b/src/google/protobuf/stubs/common.h
+@@ -86,10 +86,6 @@ namespace internal {
+ // A suffix string for alpha, beta or rc releases. Empty for stable releases.
+ #define GOOGLE_PROTOBUF_VERSION_SUFFIX ""
+ 
+-// The minimum library version which works with the current version of the
+-// headers.
+-#define GOOGLE_PROTOBUF_MIN_LIBRARY_VERSION 3007000
+-
+ // The minimum header version which works with the current version of
+ // the library.  This constant should only be used by protoc's C++ code
+ // generator.
+
+From 8f9c46b5f9636cc30134f8d6cb27f26de3bf5829 Mon Sep 17 00:00:00 2001
+From: Bo Yang <teboring@google.com>
+Date: Thu, 14 Mar 2019 05:23:22 +0000
+Subject: [PATCH 2/3] Send error if the error has been defined
+
+---
+ src/google/protobuf/port_def.inc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/google/protobuf/port_def.inc b/src/google/protobuf/port_def.inc
+index 278dd5c3d7..c75e7a347a 100644
+--- a/src/google/protobuf/port_def.inc
++++ b/src/google/protobuf/port_def.inc
+@@ -97,6 +97,9 @@
+ #ifdef PROTOBUF_MIN_HEADER_VERSION_FOR_PROTOC
+ #error PROTOBUF_MIN_HEADER_VERSION_FOR_PROTOC was previously defined
+ #endif
++#ifdef PROTOBUF_MIN_PROTOC_VERSION
++#error PROTOBUF_MIN_PROTOC_VERSION was previously defined
++#endif
+ #ifdef PROTOBUF_PREDICT_TRUE
+ #error PROTOBUF_PREDICT_TRUE was previously defined
+ #endif
+
+From 1426045c15daa29a3a03afa03e4e128787f11c51 Mon Sep 17 00:00:00 2001
+From: Bo Yang <teboring@google.com>
+Date: Fri, 15 Mar 2019 04:50:18 +0000
+Subject: [PATCH 3/3] Undef the new macro
+
+---
+ src/google/protobuf/port_undef.inc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/google/protobuf/port_undef.inc b/src/google/protobuf/port_undef.inc
+index b3177cdf31..6106c7dd4d 100644
+--- a/src/google/protobuf/port_undef.inc
++++ b/src/google/protobuf/port_undef.inc
+@@ -50,6 +50,7 @@
+ #undef PROTOBUF_VERSION_SUFFIX
+ #undef PROTOBUF_FIELD_OFFSET
+ #undef PROTOBUF_MIN_HEADER_VERSION_FOR_PROTOC
++#undef PROTOBUF_MIN_PROTOC_VERSION
+ #undef PROTOBUF_PREDICT_TRUE
+ #undef PROTOBUF_PREDICT_FALSE
+ #undef PROTOBUF_LONGLONG

--- a/recipe/LICENSE.txt
+++ b/recipe/LICENSE.txt
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) 2015-2018, conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
     sha256: a19dcfe9d156ae45d209b15e0faed5c7b5f109b6117bfc1974b6a7b98a850320
     patches:
       - 0001-remove-Werror-from-test-flags.patch  # [ppc64le]
+      - 5881.patch
   # these are git submodules from the 3.6.0 release
   # https://github.com/google/protobuf/tree/v3.6.0/third_party
   - url: https://github.com/google/benchmark/archive/5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8.zip
@@ -19,7 +20,7 @@ source:
     folder: third_party/googletest
 
 build:
-  number: 1
+  number: 2
   # Requires C++ 11, VS 2008 is not supported
   skip: True  # [win and vc<14]
   run_exports:


### PR DESCRIPTION
Adds an upstream patch to fix a missing macro definition causing many C++ projects to fail to build, e.g. https://github.com/conda-forge/staged-recipes/pull/7975

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
