### PR TITLE
Use cmake

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,22 +21,16 @@ fi
 export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 
-# Build configure/Makefile as they are not present.
-aclocal
-libtoolize
-autoconf
-autoreconf -i
-automake --add-missing
+mkdir build && cd build
 
-./configure --prefix="${PREFIX}" \
-            --build=${HOST}      \
-            --host=${HOST}       \
-            --with-pic           \
-            --with-zlib          \
-            --enable-shared      \
-            --enable-static      \
-            CC_FOR_BUILD=${CC}   \
-            CXX_FOR_BUILD=${CXX}
+cmake -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -Dprotobuf_WITH_ZLIB=ON \
+      -Dprotobuf_BUILD_SHARED_LIBS=ON \
+      $SRC_DIR/cmake
+
 if [ "${HOST}" == "powerpc64le-conda_cos7-linux-gnu" ]; then
     make -j 2
     make check -j 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     folder: third_party/googletest
 
 build:
-  number: 0
+  number: 1
   # Requires C++ 11, VS 2008 is not supported
   skip: True  # [win and vc<14]
   run_exports:
@@ -48,7 +48,6 @@ requirements:
 test:
   commands:
     - protoc --help
-    - test -f ${PREFIX}/lib/libprotobuf.a  # [not win]
     - test -f ${PREFIX}/lib/libprotobuf${SHLIB_EXT}  # [not win]
     - if not exist %PREFIX%\\Library\\lib\\libprotoc.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\libprotobuf.lib exit 1  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: "Protocol Buffers - Google's data interchange format. C++ Libraries"
+  summary: "Protocol Buffers - Google's data interchange format. C++ Libraries and protoc, the protobuf compiler."
   description: |
     Protocol buffers are Google's language-neutral,
     platform-neutral, extensible mechanism for serializing structured data-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,13 +32,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - cmake  # [win]
+    - cmake
     - ninja  # [win]
-    - autoconf  # [not win]
-    - automake  # [not win]
-    - libtool  # [not win]
-    - pkg-config  # [not win]
-    - unzip  # [not win]
     - make  # [not win]
   host:
     - zlib


### PR DESCRIPTION
Hi @xhochy 

For the time being I have also removed the static library build. Not sure if that is going to break everything :) do we need the static lib?

For me the main reason to do this is that CMake installs the files necessary to `find_package` protobuf from other projects.