### PR TITLE
change so name to match old build system

### DIFF
--- a/recipe/cmake_so_version.patch
+++ b/recipe/cmake_so_version.patch
@@ -1,0 +1,83 @@
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+index 849679995..1cc021c8e 100644
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -60,6 +60,7 @@ include(protobuf-options.cmake)
+ 
+ # Path to main configure script
+ set(protobuf_CONFIGURE_SCRIPT "../configure.ac")
++set(protobuf_MAKEFILE_AM "../src/Makefile.am")
+ 
+ # Parse configure script
+ set(protobuf_AC_INIT_REGEX
+@@ -92,6 +93,22 @@ message(STATUS "${protobuf_VERSION_PRERELEASE}")
+ set(protobuf_VERSION
+   "${protobuf_VERSION_MAJOR}.${protobuf_VERSION_MINOR}.${protobuf_VERSION_PATCH}")
+ 
++file(STRINGS "${protobuf_MAKEFILE_AM}" protobuf_SO_VERSION_LINE
++  LIMIT_COUNT 1 REGEX "^PROTOBUF_VERSION")
++
++message("ENV PROTO: ${protobuf_SO_VERSION_LINE}")
++
++string(REPLACE "PROTOBUF_VERSION = " "" protobuf_SO_VERSION "${protobuf_SO_VERSION_LINE}")
++
++message("ENV PROTO: ${protobuf_SO_VERSION}")
++
++string(REGEX MATCHALL "([^:]+)" protobuf_SO_VERSION_SPLIT "${protobuf_SO_VERSION}")
++list(GET protobuf_SO_VERSION_SPLIT 0 protobuf_SO_VERSION_CURRENT)
++list(GET protobuf_SO_VERSION_SPLIT 1 protobuf_SO_VERSION_REVISION)
++list(GET protobuf_SO_VERSION_SPLIT 2 protobuf_SO_VERSION_AGE)
++set(protobuf_SO_VERSION_FULL "${protobuf_SO_VERSION_CURRENT}.${protobuf_SO_VERSION_AGE}.${protobuf_SO_VERSION_REVISION}")
++set(protobuf_SO_VERSION "${protobuf_SO_VERSION_CURRENT}")
++
+ if(protobuf_VERSION_PRERELEASE)
+   set(protobuf_VERSION "${protobuf_VERSION}.${protobuf_VERSION_PRERELEASE}")
+ else()
+diff --git a/cmake/libprotobuf-lite.cmake b/cmake/libprotobuf-lite.cmake
+index 6bf86a277..14b48782d 100644
+--- a/cmake/libprotobuf-lite.cmake
++++ b/cmake/libprotobuf-lite.cmake
+@@ -74,7 +74,10 @@ if(MSVC AND protobuf_BUILD_SHARED_LIBS)
+     PRIVATE LIBPROTOBUF_EXPORTS)
+ endif()
+ set_target_properties(libprotobuf-lite PROPERTIES
+-    VERSION ${protobuf_VERSION}
++    SOVERSION "${protobuf_SO_VERSION}"
++    VERSION "${protobuf_SO_VERSION_FULL}"
++    OSX_CURRENT_VERSION "${protobuf_SO_VERSION_FULL}"
++    OSX_COMPATIBILITY_VERSION "${protobuf_SO_VERSION}"
+     OUTPUT_NAME ${LIB_PREFIX}protobuf-lite
+     DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")
+ add_library(protobuf::libprotobuf-lite ALIAS libprotobuf-lite)
+diff --git a/cmake/libprotobuf.cmake b/cmake/libprotobuf.cmake
+index 0c12596c2..dd0a7292f 100644
+--- a/cmake/libprotobuf.cmake
++++ b/cmake/libprotobuf.cmake
+@@ -128,7 +128,10 @@ if(MSVC AND protobuf_BUILD_SHARED_LIBS)
+     PRIVATE LIBPROTOBUF_EXPORTS)
+ endif()
+ set_target_properties(libprotobuf PROPERTIES
+-    VERSION ${protobuf_VERSION}
++    SOVERSION "${protobuf_SO_VERSION}"
++    VERSION "${protobuf_SO_VERSION_FULL}"
++    OSX_CURRENT_VERSION "${protobuf_SO_VERSION_FULL}"
++    OSX_COMPATIBILITY_VERSION "${protobuf_SO_VERSION}"
+     OUTPUT_NAME ${LIB_PREFIX}protobuf
+     DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")
+ add_library(protobuf::libprotobuf ALIAS libprotobuf)
+diff --git a/cmake/libprotoc.cmake b/cmake/libprotoc.cmake
+index b71f2f1ba..11f195fb2 100644
+--- a/cmake/libprotoc.cmake
++++ b/cmake/libprotoc.cmake
+@@ -175,7 +175,10 @@ if(MSVC AND protobuf_BUILD_SHARED_LIBS)
+ endif()
+ set_target_properties(libprotoc PROPERTIES
+     COMPILE_DEFINITIONS LIBPROTOC_EXPORTS
+-    VERSION ${protobuf_VERSION}
++    SOVERSION "${protobuf_SO_VERSION}"
++    VERSION "${protobuf_SO_VERSION_FULL}"
++    OSX_CURRENT_VERSION "${protobuf_SO_VERSION_FULL}"
++    OSX_COMPATIBILITY_VERSION "${protobuf_SO_VERSION}"
+     OUTPUT_NAME ${LIB_PREFIX}protoc
+     DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")
+ add_library(protobuf::libprotoc ALIAS libprotoc)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
     sha256: a79d19dcdf9139fa4b81206e318e33d245c4c9da1ffed21c87288ed4380426f9
     patches:
       - 0001-remove-Werror-from-test-flags.patch  # [ppc64le or aarch64]
+      - cmake_so_version.patch  # [unix]
   # these are git submodules from the 3.10.1 release
   # https://github.com/google/protobuf/tree/v3.10.1/third_party
   - url: https://github.com/google/benchmark/archive/5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8.tar.gz
@@ -44,6 +45,9 @@ test:
   commands:
     - protoc --help
     - test -f ${PREFIX}/lib/libprotobuf${SHLIB_EXT}  # [not win]
+    - test -f ${PREFIX}/lib/libprotobuf${SHLIB_EXT}.22  # [not win]
+    - test -f ${PREFIX}/lib/libprotobuf${SHLIB_EXT}.22.0.4  # [not win]
+    - 'readelf -d ${PREFIX}/lib/libprotobuf.so | grep -q "Library soname: \[libprotobuf.so.22\]"'  # [linux]
     - if not exist %PREFIX%\\Library\\lib\\libprotoc.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\libprotobuf.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\libprotobuf-lite.lib exit 1  # [win]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


@isuruf any chance you could have a look? I guess this needs your changes to cmake for OS X to work -- I don't have an OS X machine locally to test unfortunately.