### PR TITLE
RFC: export all symbols on windows

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,7 +7,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge libprotobuf_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -11,7 +11,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge libprotobuf_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -7,7 +7,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge libprotobuf_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -7,7 +7,7 @@ c_compiler_version:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge libprotobuf_dev
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -7,7 +7,7 @@ c_compiler_version:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge libprotobuf_dev
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -3,7 +3,7 @@ c_compiler:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge libprotobuf_dev
 cxx_compiler:
 - vs2017
 pin_run_as_build:

--- a/recipe/bld-shared.bat
+++ b/recipe/bld-shared.bat
@@ -12,6 +12,7 @@ cmake -G "Ninja" ^
          -DCMAKE_BUILD_TYPE=Release ^
          -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
          -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+         -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON ^
          -Dprotobuf_WITH_ZLIB=ON ^
          -Dprotobuf_BUILD_SHARED_LIBS=ON ^
          -Dprotobuf_MSVC_STATIC_RUNTIME=OFF ^

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+channel_targets:
+  - conda-forge libprotobuf_dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     folder: third_party/googletest
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libprotobuf


### PR DESCRIPTION
I believe the lack of this is the reason I'm getting the following failures in https://github.com/conda-forge/sentencepiece-feedstock/pull/26:
```
  Auto build dll exports
     Creating library D:/bld/sentencepiece-split_1638788302683/work/build/src/Release/sentencepiece_train_import.lib and object D:/bld/sentencepiece-split_1638788302683/work/build/src/Release/sentencepiece_train_import.exp
trainer_interface.obj : error LNK2019: unresolved external symbol "private: static class google::protobuf::internal::LazyString const sentencepiece::TrainerSpec::_i_give_permission_to_break_this_code_default_unk_piece_" (?_i_give_permission_to_break_this_code_default_unk_piece_@TrainerSpec@sentencepiece@@0VLazyString@internal@protobuf@google@@B) referenced in function "public: bool __cdecl <lambda_a236839460285cbab355b426097dc600>::operator()(int,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)const " (??R<lambda_a236839460285cbab355b426097dc600>@@QEBA_NHAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z) [D:\bld\sentencepiece-split_1638788302683\work\build\src\sentencepiece_train.vcxproj]
sentencepiece_trainer.obj : error LNK2001: unresolved external symbol "private: static class google::protobuf::internal::LazyString const sentencepiece::TrainerSpec::_i_give_permission_to_break_this_code_default_unk_piece_" (?_i_give_permission_to_break_this_code_default_unk_piece_@TrainerSpec@sentencepiece@@0VLazyString@internal@protobuf@google@@B) [D:\bld\sentencepiece-split_1638788302683\work\build\src\sentencepiece_train.vcxproj]
trainer_interface.obj : error LNK2019: unresolved external symbol "private: static class google::protobuf::internal::LazyString const sentencepiece::TrainerSpec::_i_give_permission_to_break_this_code_default_bos_piece_" (?_i_give_permission_to_break_this_code_default_bos_piece_@TrainerSpec@sentencepiece@@0VLazyString@internal@protobuf@google@@B) referenced in function "public: bool __cdecl <lambda_e29d05afb1d6eeb86afbc2647f25bd32>::operator()(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,enum sentencepiece::ModelProto_SentencePiece_Type)const " (??R<lambda_e29d05afb1d6eeb86afbc2647f25bd32>@@QEBA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4ModelProto_SentencePiece_Type@sentencepiece@@@Z) [D:\bld\sentencepiece-split_1638788302683\work\build\src\sentencepiece_train.vcxproj]
sentencepiece_trainer.obj : error LNK2001: unresolved external symbol "private: static class google::protobuf::internal::LazyString const sentencepiece::TrainerSpec::_i_give_permission_to_break_this_code_default_bos_piece_" (?_i_give_permission_to_break_this_code_default_bos_piece_@TrainerSpec@sentencepiece@@0VLazyString@internal@protobuf@google@@B) [D:\bld\sentencepiece-split_1638788302683\work\build\src\sentencepiece_train.vcxproj]
trainer_interface.obj : error LNK2019: unresolved external symbol "private: static class google::protobuf::internal::LazyString const sentencepiece::TrainerSpec::_i_give_permission_to_break_this_code_default_eos_piece_" (?_i_give_permission_to_break_this_code_default_eos_piece_@TrainerSpec@sentencepiece@@0VLazyString@internal@protobuf@google@@B) referenced in function "public: bool __cdecl <lambda_e29d05afb1d6eeb86afbc2647f25bd32>::operator()(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,enum sentencepiece::ModelProto_SentencePiece_Type)const " (??R<lambda_e29d05afb1d6eeb86afbc2647f25bd32>@@QEBA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4ModelProto_SentencePiece_Type@sentencepiece@@@Z) [D:\bld\sentencepiece-split_1638788302683\work\build\src\sentencepiece_train.vcxproj]
sentencepiece_trainer.obj : error LNK2001: unresolved external symbol "private: static class google::protobuf::internal::LazyString const sentencepiece::TrainerSpec::_i_give_permission_to_break_this_code_default_eos_piece_" (?_i_give_permission_to_break_this_code_default_eos_piece_@TrainerSpec@sentencepiece@@0VLazyString@internal@protobuf@google@@B) [D:\bld\sentencepiece-split_1638788302683\work\build\src\sentencepiece_train.vcxproj]
trainer_interface.obj : error LNK2019: unresolved external symbol "private: static class google::protobuf::internal::LazyString const sentencepiece::TrainerSpec::_i_give_permission_to_break_this_code_default_pad_piece_" (?_i_give_permission_to_break_this_code_default_pad_piece_@TrainerSpec@sentencepiece@@0VLazyString@internal@protobuf@google@@B) referenced in function "public: bool __cdecl <lambda_e29d05afb1d6eeb86afbc2647f25bd32>::operator()(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,enum sentencepiece::ModelProto_SentencePiece_Type)const " (??R<lambda_e29d05afb1d6eeb86afbc2647f25bd32>@@QEBA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4ModelProto_SentencePiece_Type@sentencepiece@@@Z) [D:\bld\sentencepiece-split_1638788302683\work\build\src\sentencepiece_train.vcxproj]
sentencepiece_trainer.obj : error LNK2001: unresolved external symbol "private: static class google::protobuf::internal::LazyString const sentencepiece::TrainerSpec::_i_give_permission_to_break_this_code_default_pad_piece_" (?_i_give_permission_to_break_this_code_default_pad_piece_@TrainerSpec@sentencepiece@@0VLazyString@internal@protobuf@google@@B) [D:\bld\sentencepiece-split_1638788302683\work\build\src\sentencepiece_train.vcxproj]
```

For comparison, the same recipe works for linux/osx.