### PR TITLE
Fix static libs on windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     folder: third_party/googletest
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libprotobuf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,7 +127,7 @@ outputs:
         {% for each_lib in libraries %}
         # static libraries
         - test -f ${PREFIX}/lib/{{ each_lib }}.a                       # [unix]
-        - if not exist %LIBRARY_LIB%\{{ each_lib }}.lib exit 1         # [win]
+        - if not exist %LIBRARY_LIB%\{{ each_lib }}-static.lib exit 1  # [win]
         {% endfor %}
 
         # more CMake integration (CMake uses its own FindProtobuf)

--- a/recipe/patches/0001-remove-Werror-from-test-flags.patch
+++ b/recipe/patches/0001-remove-Werror-from-test-flags.patch
@@ -1,4 +1,4 @@
-From d667a84c67f61e612017e253d84a0efa214413bd Mon Sep 17 00:00:00 2001
+From af9c0001bcc1b356baa54071f017f90a21e3cd6b Mon Sep 17 00:00:00 2001
 From: Jonathan Helmus <jjhelmus@gmail.com>
 Date: Mon, 4 Jun 2018 17:06:30 -0400
 Subject: [PATCH 1/3] remove Werror from test flags
@@ -9,7 +9,7 @@ Remove -Werror from the CXXFLAGS used for `make check`
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/Makefile.am b/src/Makefile.am
-index e6a7dc7fd..470075274 100644
+index 3a6ecdc42..3e739b0e6 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
 @@ -910,7 +910,7 @@ no_warning_test.cc:

--- a/recipe/patches/0002-use-consistent-cmake-location.patch
+++ b/recipe/patches/0002-use-consistent-cmake-location.patch
@@ -1,4 +1,4 @@
-From 06928c896573b92c000e7c069a2ef6739d87c9e3 Mon Sep 17 00:00:00 2001
+From c919a0292b80dc99f788edef852e1aad185f4cd8 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 3 Sep 2022 19:48:04 +0200
 Subject: [PATCH 2/3] use consistent cmake location

--- a/recipe/patches/0003-set-static-lib-extension-on-windows.patch
+++ b/recipe/patches/0003-set-static-lib-extension-on-windows.patch
@@ -1,4 +1,4 @@
-From 2c4529ef940209eea061954722a016c74450db51 Mon Sep 17 00:00:00 2001
+From ed8d66fb03ff296ca684359b9a7f65aeafd7e7e0 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sun, 4 Sep 2022 10:57:08 +0200
 Subject: [PATCH 3/3] set static lib extension on windows
@@ -8,18 +8,18 @@ Subject: [PATCH 3/3] set static lib extension on windows
  1 file changed, 6 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 04cb3303a..ca6144702 100644
+index 04cb3303a..9841f3f76 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -316,6 +316,12 @@ if (protobuf_BUILD_PROTOC_BINARIES)
    endif (NOT DEFINED protobuf_PROTOC_EXE)
  endif (protobuf_BUILD_PROTOC_BINARIES)
  
-+if (MSVC)
-+  set_target_properties(libprotoc PROPERTIES STATIC_SUFFIX "-static.lib")
-+  set_target_properties(libprotobuf PROPERTIES STATIC_SUFFIX "-static.lib")
-+  set_target_properties(libprotobuf-lite PROPERTIES STATIC_SUFFIX "-static.lib")
-+endif (MSVC)
++if (MSVC AND NOT protobuf_BUILD_SHARED_LIBS)
++  set_target_properties(libprotoc PROPERTIES SUFFIX "-static.lib")
++  set_target_properties(libprotobuf PROPERTIES SUFFIX "-static.lib")
++  set_target_properties(libprotobuf-lite PROPERTIES SUFFIX "-static.lib")
++endif (MSVC AND NOT protobuf_BUILD_SHARED_LIBS)
 +
  # Ensure we have a protoc executable if we need one
  if (protobuf_BUILD_TESTS OR protobuf_BUILD_CONFORMANCE OR protobuf_BUILD_EXAMPLES)


### PR DESCRIPTION
There's `CMAKE_{SHARED,STATIC,IMPORT}_LIBRARY_SUFFIX`
and there's `set_target_properties(... IMPORT_SUFFIX ...)`,
but no `STATIC_SUFFIX`. 🤷