### PR TITLE
add PROTOBUF_EXPORT to a symbol that's used by the python bindings

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,9 +20,10 @@ source:
       - patches/0003-Enable-the-selection-of-system-provided-jsoncpp-1257.patch
       - patches/0004-always-look-for-shared-abseil-builds.patch
       - patches/0005-be-more-lenient-with-abseil-version.patch
+      - patches/0006-add-PROTOBUF_EXPORT-for-google-protobuf-io-SafeDoubl.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: libprotobuf

--- a/recipe/patches/0001-use-consistent-cmake-location.patch
+++ b/recipe/patches/0001-use-consistent-cmake-location.patch
@@ -1,7 +1,7 @@
 From 5f59e8cbbea1aab58dc41e81b844d2da05863f4b Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 3 Sep 2022 19:48:04 +0200
-Subject: [PATCH 1/5] use consistent cmake location
+Subject: [PATCH 1/6] use consistent cmake location
 
 ---
  cmake/install.cmake | 12 +++---------

--- a/recipe/patches/0002-set-static-lib-extension-on-windows.patch
+++ b/recipe/patches/0002-set-static-lib-extension-on-windows.patch
@@ -1,7 +1,7 @@
 From 0e2901fac62f1fa3fc9534f4ab667fcebdff61f5 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sun, 4 Sep 2022 10:57:08 +0200
-Subject: [PATCH 2/5] set static lib extension on windows
+Subject: [PATCH 2/6] set static lib extension on windows
 
 ---
  CMakeLists.txt | 6 ++++++

--- a/recipe/patches/0003-Enable-the-selection-of-system-provided-jsoncpp-1257.patch
+++ b/recipe/patches/0003-Enable-the-selection-of-system-provided-jsoncpp-1257.patch
@@ -1,7 +1,7 @@
 From ec985b8640e701f2e21f395b453729d5b85466d3 Mon Sep 17 00:00:00 2001
 From: Mike Rochefort <mroche@omenos.dev>
 Date: Mon, 1 May 2023 09:34:17 -0700
-Subject: [PATCH 3/5] Enable the selection of system provided jsoncpp (#12577)
+Subject: [PATCH 3/6] Enable the selection of system provided jsoncpp (#12577)
 
 Allows the use of an external `jsoncpp` library to be used. Replicates the model used by `abseil-cpp` as a "package" or "module" to the `protobuf_JSONCPP_PROVIDER` option.
 

--- a/recipe/patches/0004-always-look-for-shared-abseil-builds.patch
+++ b/recipe/patches/0004-always-look-for-shared-abseil-builds.patch
@@ -1,7 +1,7 @@
 From 855774183cbd1355ca1eefaebb8699c5eb89b18d Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 13 May 2023 22:43:45 +1100
-Subject: [PATCH 4/5] always look for shared abseil builds
+Subject: [PATCH 4/6] always look for shared abseil builds
 
 ---
  cmake/abseil-cpp.cmake | 2 +-

--- a/recipe/patches/0005-be-more-lenient-with-abseil-version.patch
+++ b/recipe/patches/0005-be-more-lenient-with-abseil-version.patch
@@ -1,7 +1,7 @@
 From 3ed82472434815a3e5befcefd5e13e3bd0e07759 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Thu, 18 May 2023 09:02:21 +1100
-Subject: [PATCH 5/5] be more lenient with abseil version
+Subject: [PATCH 5/6] be more lenient with abseil version
 
 we carry the patch for the only pertinent difference
 between .2 & .3 anyway

--- a/recipe/patches/0006-add-PROTOBUF_EXPORT-for-google-protobuf-io-SafeDoubl.patch
+++ b/recipe/patches/0006-add-PROTOBUF_EXPORT-for-google-protobuf-io-SafeDoubl.patch
@@ -1,0 +1,23 @@
+From f2f930d2c30ac4020212ebcddbc4acb04eb0e3cf Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Wed, 31 May 2023 08:31:06 +1100
+Subject: [PATCH 6/6] add PROTOBUF_EXPORT for
+ google::protobuf::io::SafeDoubleToFloat
+
+---
+ src/google/protobuf/io/strtod.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/google/protobuf/io/strtod.h b/src/google/protobuf/io/strtod.h
+index 851c8e621..648f1ff1c 100644
+--- a/src/google/protobuf/io/strtod.h
++++ b/src/google/protobuf/io/strtod.h
+@@ -65,7 +65,7 @@ double NoLocaleStrtod(const char* str, char** endptr);
+ // Casts a double value to a float value. If the value is outside of the
+ // representable range of float, it will be converted to positive or negative
+ // infinity.
+-float SafeDoubleToFloat(double value);
++PROTOBUF_EXPORT float SafeDoubleToFloat(double value);
+ 
+ }  // namespace io
+ }  // namespace protobuf


### PR DESCRIPTION
Necessary for https://github.com/conda-forge/protobuf-feedstock/pull/191