### PR TITLE
Use namespaced absl::abseil_dll imported target instead of abseil_dll to correctly propagate CMake usage requirements defined in abseil build on Windows

### DIFF
--- a/recipe/cmake_test/CMakeLists.txt
+++ b/recipe/cmake_test/CMakeLists.txt
@@ -1,8 +1,10 @@
 project(cf_dummy LANGUAGES C CXX)
 cmake_minimum_required(VERSION 3.12)
-# CMake seems to prefer its own FindProtobuf to the
-# protobuf-config.cmake being distributed by this
-# feedstock; make sure things work
+# We need to specify CONFIG to make sure that CMake
+# uses protobuf-config.cmake instead of relying on its
+# own FindProtobuf.cmake that does not know about
+# abseil transitive depedendency and about C++ version
+# required, see https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/4075#issuecomment-1569242816
 find_package(Protobuf CONFIG REQUIRED)
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/struct_example.cc

--- a/recipe/cmake_test/CMakeLists.txt
+++ b/recipe/cmake_test/CMakeLists.txt
@@ -3,4 +3,22 @@ cmake_minimum_required(VERSION 3.12)
 # CMake seems to prefer its own FindProtobuf to the
 # protobuf-config.cmake being distributed by this
 # feedstock; make sure things work
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/struct_example.cc
+"
+
+#include <iostream>
+
+#include <google/protobuf/struct.pb.h>
+
+int main()
+{
+    google::protobuf::Struct myStruct;
+}
+
+"
+)
+
+add_executable(struct_example ${CMAKE_CURRENT_BINARY_DIR}/struct_example.cc)
+target_link_libraries(struct_example PRIVATE protobuf::libprotobuf)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,10 +89,11 @@ outputs:
         # binary
         - protoc --help
 
-        # more CMake integration (CMake uses its own FindProtobuf)
+        # more CMake integration
         - cd cmake_test
         - cmake -GNinja $CMAKE_ARGS .   # [unix]
         - cmake -GNinja %CMAKE_ARGS% .  # [win]
+        - cmake --build .
 
   - name: libprotobuf-static
     script: build-lib.sh   # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -131,10 +131,11 @@ outputs:
         - if not exist %LIBRARY_LIB%\{{ each_lib }}-static.lib exit 1  # [win]
         {% endfor %}
 
-        # more CMake integration (CMake uses its own FindProtobuf)
+        # more CMake integration
         - cd cmake_test
         - cmake -GNinja $CMAKE_ARGS .   # [unix]
         - cmake -GNinja %CMAKE_ARGS% .  # [win]
+        - cmake --build .
 
 about:
   home: https://developers.google.com/protocol-buffers/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,11 @@ source:
       - patches/0004-always-look-for-shared-abseil-builds.patch
       - patches/0005-be-more-lenient-with-abseil-version.patch
       - patches/0006-add-PROTOBUF_EXPORT-for-google-protobuf-io-SafeDoubl.patch
+      # backport https://github.com/protocolbuffers/protobuf/pull/12978
+      - patches/0007-use-namespaced-abseil-dll-imported-target-backport-12978.patch
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: libprotobuf

--- a/recipe/patches/0007-use-namespaced-abseil-dll-imported-target-backport-12978.patch
+++ b/recipe/patches/0007-use-namespaced-abseil-dll-imported-target-backport-12978.patch
@@ -1,0 +1,26 @@
+diff --git a/cmake/abseil-cpp.cmake b/cmake/abseil-cpp.cmake
+index e7bfb2b15f8..c668f4d9b01 100644
+--- a/cmake/abseil-cpp.cmake
++++ b/cmake/abseil-cpp.cmake
+@@ -39,8 +39,19 @@ set(_protobuf_FIND_ABSL "if(NOT TARGET absl::strings)\n  find_package(absl CONFI
+ 
+ if (BUILD_SHARED_LIBS AND MSVC)
+   # On MSVC Abseil is bundled into a single DLL.
+-  set(protobuf_ABSL_USED_TARGETS abseil_dll)
+-
++  # This condition is necessary as of abseil 20230125.3 when abseil is consumed via add_subdirectory,
++  # the abseil_dll target  is named abseil_dll, while if abseil is consumed via find_package, the target
++  # is called absl::abseil_dll
++  # Once https://github.com/abseil/abseil-cpp/pull/1466 is merged and released in the minimum version of 
++  # abseil required by protobuf, it is possible to always link absl::abseil_dll and absl::abseil_test_dll
++  # and remove the if
++  if(protobuf_ABSL_PROVIDER STREQUAL "package")
++    set(protobuf_ABSL_USED_TARGETS absl::abseil_dll)
++  else()
++    set(protobuf_ABSL_USED_TARGETS abseil_dll)
++  endif()
++  # Not all build of abseil found by find_package provide the absl::abseil_test_dll target, so for 
++  # it we stick to the non-namespaced definition
+   set(protobuf_ABSL_USED_TEST_TARGETS abseil_test_dll)
+ else()
+   set(protobuf_ABSL_USED_TARGETS


### PR DESCRIPTION
Backport of https://github.com/protocolbuffers/protobuf/pull/12978 to fix build failure on Windows such as https://github.com/conda-forge/libignition-msgs1-feedstock/pull/86#issuecomment-1575500062 .

xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/4075

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
