### PR TITLE
Include generated cmake files inside the static package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
       - patches/0008-CMake-Fix-abseil_dll-target-name-when-using-find_pac.patch
 
 build:
-  number: 4
+  number: 5
 
 outputs:
   - name: libprotobuf
@@ -100,6 +100,10 @@ outputs:
     script: build-lib.sh   # [unix]
     script: build-lib.bat  # [win]
     build:
+      always_include_files:
+        # Must overwrite the CMake metadata from shared libprotobuf
+        - lib/cmake/protobuf/           # [unix]
+        - Library/lib/cmake/protobuf/   # [win]
       ignore_run_exports_from:
         - jsoncpp
     requirements:


### PR DESCRIPTION
- addresses https://github.com/conda-forge/libprotobuf-feedstock/issues/164
- makes sure that libprotobuf-static bundles proper cmake files (one for static flavor, not dynamic one)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
