### PR TITLE
Add run_constrained for libprotobuf-python-headers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
       - patches/0006-do-not-install-vendored-gmock.patch
 
 build:
-  number: 3
+  number: 4
 
 outputs:
   - name: libprotobuf
@@ -151,6 +151,8 @@ outputs:
         - rsync  # [unix]
       host:
         - {{ pin_subpackage('libprotobuf', exact=True) }}
+      run_constrained:
+        - libprotobuf {{ version }}
     test:
       commands:
         - test -f $PREFIX/include/google/protobuf/proto_api.h      # [unix]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
