### PR TITLE
Fix gtest dependence

### DIFF
--- a/.ci_support/migrations/libabseil20230802_libgrpc157_libprotobuf4234.yaml
+++ b/.ci_support/migrations/libabseil20230802_libgrpc157_libprotobuf4234.yaml
@@ -1,0 +1,13 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+libabseil:
+- 20230802
+libgrpc:
+- "1.57"
+libprotobuf:
+- 4.23.4
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+- "10.13"                  # [osx and x86_64]
+migrator_ts: 1692632590.658328

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_compiler:
 - clang
 c_compiler_version:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,0 @@
-# abseil 20230802 now only support MacOS >=10.13, reflect this here
-MACOSX_SDK_VERSION:        # [osx and x86_64]
-  - "10.13"                # [osx and x86_64]
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
-  - "10.13"                # [osx and x86_64]
-
-# manual pin because we're linking migrations
-libabseil:
-  - 20230802

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ outputs:
         # https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/4075
         - {{ pin_subpackage('libprotobuf', max_pin='x.x.x') }}
       ignore_run_exports_from:
+        - gtest
         - jsoncpp
     requirements:
       build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
       - patches/0006-do-not-install-vendored-gmock.patch
 
 build:
-  number: 5
+  number: 6
 
 outputs:
   - name: libprotobuf


### PR DESCRIPTION
Fixes #186 

This didn't use to be an issue, but we've since added https://github.com/conda-forge/gtest-feedstock/commit/8416a39e5e7329e8cb9c91e808a7a4c5b7c09c5c, so now we need to ignore the run-export of gtest.