### PR TITLE
[4.24.3] Added -framework CoreFoundation to LDFLAGS on OSX

### DIFF
--- a/recipe/build-lib.sh
+++ b/recipe/build-lib.sh
@@ -13,7 +13,7 @@ elif [[ "$(uname)" == "Darwin" ]]; then
     # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
     # remove pie from LDFLAGS
-    LDFLAGS="${LDFLAGS//-pie/}"
+    LDFLAGS="${LDFLAGS//-pie/} -framework CoreFoundation"
 fi
 
 # required to pick up conda installed zlib

--- a/recipe/build-lib.sh
+++ b/recipe/build-lib.sh
@@ -13,7 +13,9 @@ elif [[ "$(uname)" == "Darwin" ]]; then
     # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
     # remove pie from LDFLAGS
-    LDFLAGS="${LDFLAGS//-pie/} -framework CoreFoundation"
+    LDFLAGS="${LDFLAGS//-pie/}"
+    # CoreFoundation is needed as least as of libprotobuf>=4.23.X
+    LDFLAGS="${LDFLAGS} -framework CoreFoundation"
 fi
 
 # required to pick up conda installed zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
       - patches/0005-do-not-install-vendored-gmock.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libprotobuf


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

This should fix https://github.com/conda-forge/arcticdb-feedstock/pull/89 , currently failing with the following:
```
ImportError: dlopen(/Users/runner/miniforge3/conda-bld/arcticdb_1697103681425/_h_env_placehold_[...]/lib/python3.8/site-packages/grpc_tools/_protoc_compiler.cpython-38-darwin.so, 2): Symbol not found: _CFRelease
```

cc @jjerphan