### PR TITLE
[main] Add -framework CoreFoundation to LDFLAGS on OSX

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,6 @@
 bot:
   abi_migration_branches:
-  - 4.23.3
+  - 4.24.3
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64

--- a/recipe/build-lib.sh
+++ b/recipe/build-lib.sh
@@ -14,6 +14,8 @@ elif [[ "$(uname)" == "Darwin" ]]; then
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
     # remove pie from LDFLAGS
     LDFLAGS="${LDFLAGS//-pie/}"
+    # CoreFoundation is needed as least as of libprotobuf>=4.23.X
+    LDFLAGS="${LDFLAGS} -framework CoreFoundation"
 fi
 
 # required to pick up conda installed zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
       - patches/0005-do-not-install-vendored-gmock.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libprotobuf


### PR DESCRIPTION
Forward-port #191; let's wait with merging to see if it has the intended effect for 4.24.3