### PR TITLE
Backport fix for Tensorflow to 4.25.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,14 @@ source:
       - patches/0004-Export-functions-in-google-compiler-java-names.patch
       - patches/0005-do-not-install-vendored-gmock.patch
       - patches/0006-Fix-getting-env-variables-on-windows.patch
+      # Backport from 4.26.0rc1 for
+      # https://github.com/conda-forge/libprotobuf-feedstock/issues/206
+      # taken from
+      # https://github.com/protocolbuffers/protobuf/commit/f78f9c51fa2470070e5d4b49649800971c789224
+      - patches/fix_constexpr_vtble.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libprotobuf

--- a/recipe/patches/fix_constexpr_vtble.patch
+++ b/recipe/patches/fix_constexpr_vtble.patch
@@ -1,0 +1,24 @@
+From f78f9c51fa2470070e5d4b49649800971c789224 Mon Sep 17 00:00:00 2001
+From: Protobuf Team Bot <protobuf-github-bot@google.com>
+Date: Thu, 2 Nov 2023 09:13:31 -0700
+Subject: [PATCH] Workaround false positive warning in MSVC. Fixes
+ https://github.com/protocolbuffers/protobuf/issues/14602
+
+PiperOrigin-RevId: 578875053
+---
+ src/google/protobuf/map_field.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/google/protobuf/map_field.h b/src/google/protobuf/map_field.h
+index 8aa9e45fe3e..8388f8a2e52 100644
+--- a/src/google/protobuf/map_field.h
++++ b/src/google/protobuf/map_field.h
+@@ -678,7 +678,7 @@ class MapField final : public TypeDefinedMapFieldBase<Key, T> {
+ template <typename Derived, typename Key, typename T,
+           WireFormatLite::FieldType kKeyFieldType_,
+           WireFormatLite::FieldType kValueFieldType_>
+-constexpr MapFieldBase::VTable
++PROTOBUF_CONSTINIT const MapFieldBase::VTable
+     MapField<Derived, Key, T, kKeyFieldType_, kValueFieldType_>::kVTable =
+         MapField::template MakeVTable<MapField>();
+ 


### PR DESCRIPTION
Lets just see if this compiles

Closes https://github.com/conda-forge/libprotobuf-feedstock/issues/206

I mostly want to make it easy to take the action if it is deemed ok.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
