### PR TITLE
[main] fix pkgconfig metadata on windows and tighten tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,9 @@ source:
       - patches/0007-Workaround-false-positive-warning-in-MSVC.-Fixes-htt.patch
       # fix for https://github.com/protocolbuffers/protobuf/issues/15883
       - patches/0008-fix-pkg-config-metadata-for-shared-abseil-on-windows.patch
+      # skip annoyingly flaky test on windows, see
+      # https://github.com/protocolbuffers/protobuf/issues/8645
+      - patches/0009-disable-MapImplTest.RandomOrdering-due-to-flakiness.patch      # [win]
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,9 +24,11 @@ source:
       - patches/0006-Fix-getting-env-variables-on-windows.patch
       # backport https://github.com/protocolbuffers/protobuf/commit/f78f9c51fa2470070e5d4b49649800971c789224
       - patches/0007-Workaround-false-positive-warning-in-MSVC.-Fixes-htt.patch
+      # fix for https://github.com/protocolbuffers/protobuf/issues/15883
+      - patches/0008-fix-pkg-config-metadata-for-shared-abseil-on-windows.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libprotobuf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,6 +68,7 @@ outputs:
         - {{ compiler('cxx') }}
         - cmake
         - ninja
+        - pkg-config
       files:
         - cmake_test/
       commands:
@@ -87,11 +88,9 @@ outputs:
         - test -f ${PREFIX}/lib/cmake/protobuf/protobuf-config.cmake              # [unix]
         - if not exist %LIBRARY_LIB%\cmake\protobuf\protobuf-config.cmake exit 1  # [win]
 
-        # pkgconfig
-        - test -f ${PREFIX}/lib/pkgconfig/protobuf.pc                   # [unix]
-        - test -f ${PREFIX}/lib/pkgconfig/protobuf-lite.pc              # [unix]
-        - if not exist %LIBRARY_LIB%\pkgconfig\protobuf.pc exit 1       # [win]
-        - if not exist %LIBRARY_LIB%\pkgconfig\protobuf-lite.pc exit 1  # [win]
+        # pkg-config
+        - pkg-config --print-errors --exact-version "{{ version }}.0" protobuf
+        - pkg-config --print-errors --exact-version "{{ version }}.0" protobuf-lite
 
         # binary
         - protoc --help

--- a/recipe/patches/0001-use-consistent-cmake-location.patch
+++ b/recipe/patches/0001-use-consistent-cmake-location.patch
@@ -1,7 +1,7 @@
 From df4354948bbcf18e6a41fc5743724fe85b166bc2 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 3 Sep 2022 19:48:04 +0200
-Subject: [PATCH 1/7] use consistent cmake location
+Subject: [PATCH 1/8] use consistent cmake location
 
 ---
  cmake/install.cmake | 12 +++---------

--- a/recipe/patches/0001-use-consistent-cmake-location.patch
+++ b/recipe/patches/0001-use-consistent-cmake-location.patch
@@ -1,7 +1,7 @@
 From df4354948bbcf18e6a41fc5743724fe85b166bc2 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 3 Sep 2022 19:48:04 +0200
-Subject: [PATCH 1/8] use consistent cmake location
+Subject: [PATCH 1/9] use consistent cmake location
 
 ---
  cmake/install.cmake | 12 +++---------

--- a/recipe/patches/0002-set-static-lib-extension-on-windows.patch
+++ b/recipe/patches/0002-set-static-lib-extension-on-windows.patch
@@ -1,7 +1,7 @@
 From 6137fefd543de0aca634ef820f83f7e9d6e6f075 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sun, 4 Sep 2022 10:57:08 +0200
-Subject: [PATCH 2/7] set static lib extension on windows
+Subject: [PATCH 2/8] set static lib extension on windows
 
 ---
  CMakeLists.txt | 6 ++++++

--- a/recipe/patches/0002-set-static-lib-extension-on-windows.patch
+++ b/recipe/patches/0002-set-static-lib-extension-on-windows.patch
@@ -1,7 +1,7 @@
 From 6137fefd543de0aca634ef820f83f7e9d6e6f075 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sun, 4 Sep 2022 10:57:08 +0200
-Subject: [PATCH 2/8] set static lib extension on windows
+Subject: [PATCH 2/9] set static lib extension on windows
 
 ---
  CMakeLists.txt | 6 ++++++

--- a/recipe/patches/0003-always-look-for-shared-abseil-builds.patch
+++ b/recipe/patches/0003-always-look-for-shared-abseil-builds.patch
@@ -1,7 +1,7 @@
 From ce158be9e2ae9baed2a31ed978c2f33c567c01c4 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 13 May 2023 22:43:45 +1100
-Subject: [PATCH 3/8] always look for shared abseil builds
+Subject: [PATCH 3/9] always look for shared abseil builds
 
 ---
  cmake/abseil-cpp.cmake | 2 +-

--- a/recipe/patches/0003-always-look-for-shared-abseil-builds.patch
+++ b/recipe/patches/0003-always-look-for-shared-abseil-builds.patch
@@ -1,7 +1,7 @@
 From ce158be9e2ae9baed2a31ed978c2f33c567c01c4 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 13 May 2023 22:43:45 +1100
-Subject: [PATCH 3/7] always look for shared abseil builds
+Subject: [PATCH 3/8] always look for shared abseil builds
 
 ---
  cmake/abseil-cpp.cmake | 2 +-

--- a/recipe/patches/0004-Export-functions-in-google-compiler-java-names.patch
+++ b/recipe/patches/0004-Export-functions-in-google-compiler-java-names.patch
@@ -1,7 +1,7 @@
 From b4ad926042037d3f40604bf7fa617f49cb426399 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Wed, 14 Jun 2023 11:36:55 +0200
-Subject: [PATCH 4/7] Export functions in google::compiler::java::names
+Subject: [PATCH 4/8] Export functions in google::compiler::java::names
 
 ---
  src/google/protobuf/compiler/java/names.h | 20 ++++++++++----------

--- a/recipe/patches/0004-Export-functions-in-google-compiler-java-names.patch
+++ b/recipe/patches/0004-Export-functions-in-google-compiler-java-names.patch
@@ -1,7 +1,7 @@
 From b4ad926042037d3f40604bf7fa617f49cb426399 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Wed, 14 Jun 2023 11:36:55 +0200
-Subject: [PATCH 4/8] Export functions in google::compiler::java::names
+Subject: [PATCH 4/9] Export functions in google::compiler::java::names
 
 ---
  src/google/protobuf/compiler/java/names.h | 20 ++++++++++----------

--- a/recipe/patches/0005-do-not-install-vendored-gmock.patch
+++ b/recipe/patches/0005-do-not-install-vendored-gmock.patch
@@ -1,7 +1,7 @@
 From 8e04212bac883743aea9e19e77976f44ffdb5ad6 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 9 Aug 2023 14:06:35 +1100
-Subject: [PATCH 5/7] do not install vendored gmock
+Subject: [PATCH 5/8] do not install vendored gmock
 
 ---
  cmake/install.cmake | 7 -------

--- a/recipe/patches/0005-do-not-install-vendored-gmock.patch
+++ b/recipe/patches/0005-do-not-install-vendored-gmock.patch
@@ -1,7 +1,7 @@
 From 8e04212bac883743aea9e19e77976f44ffdb5ad6 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 9 Aug 2023 14:06:35 +1100
-Subject: [PATCH 5/8] do not install vendored gmock
+Subject: [PATCH 5/9] do not install vendored gmock
 
 ---
  cmake/install.cmake | 7 -------

--- a/recipe/patches/0006-Fix-getting-env-variables-on-windows.patch
+++ b/recipe/patches/0006-Fix-getting-env-variables-on-windows.patch
@@ -1,7 +1,7 @@
 From ceff6146f5e57b38dd4bd3e66b4798721f57179c Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Fri, 19 Jan 2024 19:14:50 -0600
-Subject: [PATCH 6/8] Fix getting env variables on windows
+Subject: [PATCH 6/9] Fix getting env variables on windows
 
 ---
  src/google/protobuf/compiler/mock_code_generator.cc | 8 +++++++-

--- a/recipe/patches/0006-Fix-getting-env-variables-on-windows.patch
+++ b/recipe/patches/0006-Fix-getting-env-variables-on-windows.patch
@@ -1,7 +1,7 @@
 From ceff6146f5e57b38dd4bd3e66b4798721f57179c Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Fri, 19 Jan 2024 19:14:50 -0600
-Subject: [PATCH 6/7] Fix getting env variables on windows
+Subject: [PATCH 6/8] Fix getting env variables on windows
 
 ---
  src/google/protobuf/compiler/mock_code_generator.cc | 8 +++++++-

--- a/recipe/patches/0007-Workaround-false-positive-warning-in-MSVC.-Fixes-htt.patch
+++ b/recipe/patches/0007-Workaround-false-positive-warning-in-MSVC.-Fixes-htt.patch
@@ -1,7 +1,7 @@
 From 96948fa966e91df3fe6b4a788152b0b83c2ca9b6 Mon Sep 17 00:00:00 2001
 From: Protobuf Team Bot <protobuf-github-bot@google.com>
 Date: Thu, 2 Nov 2023 09:13:31 -0700
-Subject: [PATCH 7/7] Workaround false positive warning in MSVC. Fixes
+Subject: [PATCH 7/8] Workaround false positive warning in MSVC. Fixes
  https://github.com/protocolbuffers/protobuf/issues/14602
 
 PiperOrigin-RevId: 578875053

--- a/recipe/patches/0007-Workaround-false-positive-warning-in-MSVC.-Fixes-htt.patch
+++ b/recipe/patches/0007-Workaround-false-positive-warning-in-MSVC.-Fixes-htt.patch
@@ -1,7 +1,7 @@
 From 96948fa966e91df3fe6b4a788152b0b83c2ca9b6 Mon Sep 17 00:00:00 2001
 From: Protobuf Team Bot <protobuf-github-bot@google.com>
 Date: Thu, 2 Nov 2023 09:13:31 -0700
-Subject: [PATCH 7/8] Workaround false positive warning in MSVC. Fixes
+Subject: [PATCH 7/9] Workaround false positive warning in MSVC. Fixes
  https://github.com/protocolbuffers/protobuf/issues/14602
 
 PiperOrigin-RevId: 578875053

--- a/recipe/patches/0008-fix-pkg-config-metadata-for-shared-abseil-on-windows.patch
+++ b/recipe/patches/0008-fix-pkg-config-metadata-for-shared-abseil-on-windows.patch
@@ -1,7 +1,7 @@
 From c0759889e6f5a9899532e54bde8232564a1ff8dc Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 20 Feb 2024 20:27:36 +1100
-Subject: [PATCH 8/8] fix pkg-config metadata for shared abseil on windows
+Subject: [PATCH 8/9] fix pkg-config metadata for shared abseil on windows
 
 ---
  cmake/install.cmake | 5 ++++-

--- a/recipe/patches/0008-fix-pkg-config-metadata-for-shared-abseil-on-windows.patch
+++ b/recipe/patches/0008-fix-pkg-config-metadata-for-shared-abseil-on-windows.patch
@@ -1,0 +1,25 @@
+From c0759889e6f5a9899532e54bde8232564a1ff8dc Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Tue, 20 Feb 2024 20:27:36 +1100
+Subject: [PATCH 8/8] fix pkg-config metadata for shared abseil on windows
+
+---
+ cmake/install.cmake | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/cmake/install.cmake b/cmake/install.cmake
+index f68ec217b..60871aab9 100644
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
+@@ -1,7 +1,10 @@
+ include(GNUInstallDirs)
+ 
+ foreach(_target IN LISTS protobuf_ABSL_USED_TARGETS)
+-  string(REPLACE :: _ _modified_target ${_target})
++  # shared abseil on windows breaks the absl::foo -> absl_foo replacement logic -
++  # preempt this by a more specific replace (harmless if it doesn't apply); see GH-15883
++  string(REPLACE "absl::abseil_dll" "abseil_dll" _modified_target ${_target})
++  string(REPLACE :: _ _modified_target ${_modified_target})
+   list(APPEND _pc_targets ${_modified_target})
+ endforeach()
+ list(APPEND _pc_targets "utf8_range")

--- a/recipe/patches/0009-disable-MapImplTest.RandomOrdering-due-to-flakiness.patch
+++ b/recipe/patches/0009-disable-MapImplTest.RandomOrdering-due-to-flakiness.patch
@@ -1,0 +1,23 @@
+From 02bcda9d01dd12ecf641dba54e0832a97de989f5 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Tue, 20 Feb 2024 22:21:55 +1100
+Subject: [PATCH 9/9] disable MapImplTest.RandomOrdering due to flakiness
+
+see https://google.github.io/googletest/advanced.html#temporarily-disabling-tests
+---
+ src/google/protobuf/map_test.inc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/google/protobuf/map_test.inc b/src/google/protobuf/map_test.inc
+index c1b002987..34d45f44d 100644
+--- a/src/google/protobuf/map_test.inc
++++ b/src/google/protobuf/map_test.inc
+@@ -1344,7 +1344,7 @@ bool MapOrderingIsRandom(int a, int b) {
+ 
+ // This test verifies that the iteration order is reasonably random even for
+ // small maps.
+-TEST_F(MapImplTest, RandomOrdering) {
++TEST_F(MapImplTest, DISABLED_RandomOrdering) {
+   for (int i = 0; i < 10; ++i) {
+     for (int j = i + 1; j < 10; ++j) {
+       EXPECT_TRUE(MapOrderingIsRandom(i, j))


### PR DESCRIPTION
pkgconfig data on windows is wrong, is looking for `absl_abseil_dll`, which obviously doesn't exist. Tighten the tests, then fix it.