### PR TITLE
libprotobuf v5.29.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 # keep this without major version to let the bot pick it up
-{% set version = "29.0" %}
+{% set version = "29.1" %}
 # protobuf doesn't add the major version in the tag, it's defined per language in
 # https://github.com/protocolbuffers/protobuf/blob/main/version.json
 {% set major = "5" %}
@@ -20,7 +20,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/refs/tags/v{{ version.replace(".rc", "-rc") }}.tar.gz
-    sha256: 10a0d58f39a1a909e95e00e8ba0b5b1dc64d02997f741151953a2b3659f6e78c
+    sha256: 3d32940e975c4ad9b8ba69640e78f5527075bae33ca2890275bf26b853c0962c
     patches:
       - patches/0001-set-static-lib-extension-on-windows.patch
       - patches/0002-always-look-for-shared-abseil-builds.patch
@@ -32,7 +32,7 @@ source:
       - patches/0005-disable-MapImplTest.RandomOrdering-due-to-flakiness.patch      # [win]
 
 build:
-  number: 1
+  number: 0
 
 outputs:
   - name: libprotobuf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,14 @@ source:
       # skip annoyingly flaky test on windows, see
       # https://github.com/protocolbuffers/protobuf/issues/8645
       - patches/0005-disable-MapImplTest.RandomOrdering-due-to-flakiness.patch      # [win]
+      # windows has a non-default prefix for the library names (e.g. libprotobuf.lib
+      # instead of protobuf.lib); this is fixed in the CMake metadata, but wrong in
+      # in the metadata for pkgconfig. While this should ideally be solved more
+      # comprehensively (c.f. https://github.com/protocolbuffers/protobuf/issues/20515),
+      # at least fix it for upb for now, which doesn't have its own `.cmake` files
+      # (though there's a `protobuf::libupb` target, it's not that obvious), see
+      # https://github.com/protocolbuffers/protobuf/blob/v29.1/cmake/libupb.cmake
+      - patches/0006-fix-naming-divergence-on-windows-in-pkgconfig-metada.patch     # [win]
 
 build:
   number: 0

--- a/recipe/patches/0001-set-static-lib-extension-on-windows.patch
+++ b/recipe/patches/0001-set-static-lib-extension-on-windows.patch
@@ -1,14 +1,14 @@
-From 7e42d50fd7d3acf137ac7ff7be709c05d06c7f8e Mon Sep 17 00:00:00 2001
+From ae477048f455f28c8ff43f87701951b75a670526 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sun, 4 Sep 2022 10:57:08 +0200
-Subject: [PATCH 1/5] set static lib extension on windows
+Subject: [PATCH 1/6] set static lib extension on windows
 
 ---
  CMakeLists.txt | 6 ++++++
  1 file changed, 6 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b269fff..615fba8 100644
+index a3aaa49b8..d3ae84c8a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -342,6 +342,12 @@ else ()

--- a/recipe/patches/0002-always-look-for-shared-abseil-builds.patch
+++ b/recipe/patches/0002-always-look-for-shared-abseil-builds.patch
@@ -1,14 +1,14 @@
-From f5b56d5232dce108e4904f6cb66c67a4b2389772 Mon Sep 17 00:00:00 2001
+From 1687bad287717b68f2ff4f1aac31cee8e8ae4858 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 13 May 2023 22:43:45 +1100
-Subject: [PATCH 2/5] always look for shared abseil builds
+Subject: [PATCH 2/6] always look for shared abseil builds
 
 ---
  cmake/abseil-cpp.cmake | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/cmake/abseil-cpp.cmake b/cmake/abseil-cpp.cmake
-index 1b64aff..cced07e 100644
+index 1b64affa5..cced07ef1 100644
 --- a/cmake/abseil-cpp.cmake
 +++ b/cmake/abseil-cpp.cmake
 @@ -37,7 +37,7 @@ elseif(protobuf_ABSL_PROVIDER STREQUAL "package")

--- a/recipe/patches/0003-Export-functions-in-google-compiler-java-names.patch
+++ b/recipe/patches/0003-Export-functions-in-google-compiler-java-names.patch
@@ -1,14 +1,14 @@
-From a1a3810d0e86448e0efa9067d06865207c4035d8 Mon Sep 17 00:00:00 2001
+From 5f60ff25d7354d4f2efd04bfd269a31a63f44793 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Wed, 14 Jun 2023 11:36:55 +0200
-Subject: [PATCH 3/5] Export functions in google::compiler::java::names
+Subject: [PATCH 3/6] Export functions in google::compiler::java::names
 
 ---
  src/google/protobuf/compiler/java/names.h | 26 +++++++++++------------
  1 file changed, 13 insertions(+), 13 deletions(-)
 
 diff --git a/src/google/protobuf/compiler/java/names.h b/src/google/protobuf/compiler/java/names.h
-index c2eb34c..426742a 100644
+index c2eb34cb3..426742a04 100644
 --- a/src/google/protobuf/compiler/java/names.h
 +++ b/src/google/protobuf/compiler/java/names.h
 @@ -41,35 +41,35 @@ namespace java {

--- a/recipe/patches/0004-do-not-install-vendored-gmock.patch
+++ b/recipe/patches/0004-do-not-install-vendored-gmock.patch
@@ -1,17 +1,17 @@
-From 07c82abcecf368d838c2cb7238e748cae5e2188f Mon Sep 17 00:00:00 2001
+From d36a74a66339a77f2da3c3cd6c5f5a7c76d9194a Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 9 Aug 2023 14:06:35 +1100
-Subject: [PATCH 4/5] do not install vendored gmock
+Subject: [PATCH 4/6] do not install vendored gmock
 
 ---
  cmake/install.cmake | 7 -------
  1 file changed, 7 deletions(-)
 
 diff --git a/cmake/install.cmake b/cmake/install.cmake
-index 65765ca..442df60 100644
+index bf5650984..2dd8c5c38 100644
 --- a/cmake/install.cmake
 +++ b/cmake/install.cmake
-@@ -162,10 +162,3 @@ if(protobuf_INSTALL_EXAMPLES)
+@@ -169,10 +169,3 @@ if(protobuf_INSTALL_EXAMPLES)
      DESTINATION "${CMAKE_INSTALL_EXAMPLEDIR}"
      COMPONENT protobuf-examples)
  endif()

--- a/recipe/patches/0005-disable-MapImplTest.RandomOrdering-due-to-flakiness.patch
+++ b/recipe/patches/0005-disable-MapImplTest.RandomOrdering-due-to-flakiness.patch
@@ -1,7 +1,7 @@
-From 5e664bba6f15971b559219876e68b731c895ce53 Mon Sep 17 00:00:00 2001
+From f9190719dc421844b8cf3c2e266091454db8ad26 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 20 Feb 2024 22:21:55 +1100
-Subject: [PATCH 5/5] disable MapImplTest.RandomOrdering due to flakiness
+Subject: [PATCH 5/6] disable MapImplTest.RandomOrdering due to flakiness
 
 see https://google.github.io/googletest/advanced.html#temporarily-disabling-tests
 ---
@@ -9,10 +9,10 @@ see https://google.github.io/googletest/advanced.html#temporarily-disabling-test
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/google/protobuf/map_test.inc b/src/google/protobuf/map_test.inc
-index 4b75234..0a6a356 100644
+index 6e4d261c1..4e7414a68 100644
 --- a/src/google/protobuf/map_test.inc
 +++ b/src/google/protobuf/map_test.inc
-@@ -1350,7 +1350,7 @@ bool MapOrderingIsRandom(int a, int b) {
+@@ -1358,7 +1358,7 @@ bool MapOrderingIsRandom(int a, int b) {
  
  // This test verifies that the iteration order is reasonably random even for
  // small maps.

--- a/recipe/patches/0006-fix-naming-divergence-on-windows-in-pkgconfig-metada.patch
+++ b/recipe/patches/0006-fix-naming-divergence-on-windows-in-pkgconfig-metada.patch
@@ -1,0 +1,20 @@
+From 013f10dbac58087de348f14dc7f374260ec33d6e Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Fri, 28 Feb 2025 18:50:17 +1100
+Subject: [PATCH 6/6] fix naming divergence on windows in pkgconfig metadata
+
+---
+ cmake/upb.pc.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/upb.pc.cmake b/cmake/upb.pc.cmake
+index b1d9900de..b54522f2c 100644
+--- a/cmake/upb.pc.cmake
++++ b/cmake/upb.pc.cmake
+@@ -6,5 +6,5 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ Name: Protocol Buffers
+ Description: Google's Data Interchange Format
+ Version: @protobuf_VERSION@
+-Libs: -L${libdir} -lupb @CMAKE_THREAD_LIBS_INIT@
++Libs: -L${libdir} -llibupb @CMAKE_THREAD_LIBS_INIT@
+ Cflags: -I${includedir}


### PR DESCRIPTION
I need to build `protobuf` to test grpc, but v29.0 was [yanked](https://github.com/conda-forge/protobuf-feedstock/pull/233), so bump patch version here (although I would have wished to build as few different versions/builds while figuring out the upb situation...)