### PR TITLE
update patch for upb/wire header; add test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ source:
       - patches/0007-install-a-missing-upb-header.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: libprotobuf
@@ -103,6 +103,11 @@ outputs:
         - test -f ${PREFIX}/lib/libupb.a                # [unix]
         - if not exist %LIBRARY_INC%\upb exit 1         # [win]
         - if not exist %LIBRARY_LIB%\libupb.lib exit 1  # [win]
+
+        # upb headers needed by protobuf, see
+        # https://github.com/protocolbuffers/protobuf/issues/20522
+        - test -f ${PREFIX}/include/upb/wire/internal/reader.h          # [unix]
+        - if not exist %LIBRARY_INC%\upb\wire\internal\reader.h exit 1  # [win]
 
         # cmake
         - test -f ${PREFIX}/lib/cmake/protobuf/protobuf-config.cmake              # [unix]

--- a/recipe/patches/0007-install-a-missing-upb-header.patch
+++ b/recipe/patches/0007-install-a-missing-upb-header.patch
@@ -1,26 +1,22 @@
-From 2b38aea6c706a3a8bcc403bf04d27a44eb48bf9d Mon Sep 17 00:00:00 2001
+From e1cde241fbd9d0cb4ceeb66dde7af51cdf84dce3 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Fri, 28 Feb 2025 21:31:52 +1100
 Subject: [PATCH 7/7] install a missing upb header
 
 see https://github.com/protocolbuffers/protobuf/issues/20522
 ---
- upb/wire/BUILD | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ src/file_lists.cmake | 1 +
+ 1 file changed, 1 insertion(+)
 
-diff --git a/upb/wire/BUILD b/upb/wire/BUILD
-index 23a5239d6..44eb1b986 100644
---- a/upb/wire/BUILD
-+++ b/upb/wire/BUILD
-@@ -46,10 +46,10 @@ cc_library(
- cc_library(
-     name = "reader",
-     srcs = [
--        "internal/reader.h",
-         "reader.c",
-     ],
-     hdrs = [
-+        "internal/reader.h",
-         "reader.h",
-         "types.h",
-     ],
+diff --git a/src/file_lists.cmake b/src/file_lists.cmake
+index 559c15fe3..431682797 100644
+--- a/src/file_lists.cmake
++++ b/src/file_lists.cmake
+@@ -740,6 +740,7 @@ set(libupb_hdrs
+   ${protobuf_SOURCE_DIR}/upb/wire/encode.h
+   ${protobuf_SOURCE_DIR}/upb/wire/eps_copy_input_stream.h
+   ${protobuf_SOURCE_DIR}/upb/wire/internal/decode_fast.h
++  ${protobuf_SOURCE_DIR}/upb/wire/internal/reader.h
+   ${protobuf_SOURCE_DIR}/upb/wire/reader.h
+   ${protobuf_SOURCE_DIR}/upb/wire/types.h
+ )


### PR DESCRIPTION
https://github.com/conda-forge/libprotobuf-feedstock/commit/416ebee233e7c103c09d1a87d348db3e210507b2 patched the wrong side (bazel instead of CMake; couldn't find the location where the latter was operating at first).