### PR TITLE
build UPB API

### DIFF
--- a/recipe/build-lib.bat
+++ b/recipe/build-lib.bat
@@ -2,10 +2,12 @@
 
 if "%PKG_NAME%"=="libprotobuf-static" (
     set CF_SHARED=OFF
+    set CF_TESTS=OFF
     mkdir build-static
     cd build-static
 ) else (
     set CF_SHARED=ON
+    set CF_TESTS=ON
     mkdir build-shared
     cd build-shared
 )
@@ -19,6 +21,7 @@ cmake -G "Ninja" ^
     -Dprotobuf_ABSL_PROVIDER="package" ^
     -Dprotobuf_BUILD_LIBUPB=ON ^
     -Dprotobuf_BUILD_SHARED_LIBS=%CF_SHARED% ^
+    -Dprotobuf_BUILD_TESTS=%CF_TESTS% ^
     -Dprotobuf_JSONCPP_PROVIDER="package" ^
     -Dprotobuf_MSVC_STATIC_RUNTIME=OFF ^
     -Dprotobuf_USE_EXTERNAL_GTEST=ON ^
@@ -29,8 +32,10 @@ if %ERRORLEVEL% neq 0 exit 1
 cmake --build .
 if %ERRORLEVEL% neq 0 exit 1
 
-ctest --progress --output-on-failure
-if %ERRORLEVEL% neq 0 exit 1
+if "%PKG_NAME%"=="libprotobuf" (
+    ctest --progress --output-on-failure
+    if %ERRORLEVEL% neq 0 exit 1
+)
 
 cmake --install .
 if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/build-lib.sh
+++ b/recipe/build-lib.sh
@@ -18,8 +18,9 @@ elif [[ "$(uname)" == "Darwin" ]]; then
     LDFLAGS="${LDFLAGS} -framework CoreFoundation"
 fi
 
-# required to pick up conda installed zlib
-export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+# required to pick up conda installed zlib; ensure UPB symbols are visible, see
+# https://github.com/protocolbuffers/protobuf/blob/v29.1/upb/port/def.inc#L69-L91
+export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include -DUPB_BUILD_API"
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 
 # delete vendored gtest to force protobuf_USE_EXTERNAL_GTEST to work;

--- a/recipe/build-lib.sh
+++ b/recipe/build-lib.sh
@@ -28,16 +28,18 @@ rm -rf ./third_party/googletest | true
 
 if [[ "$PKG_NAME" == "libprotobuf-static" ]]; then
     export CF_SHARED=OFF
+    export CF_TESTS=OFF
     mkdir build-static
     cd build-static
 else
     export CF_SHARED=ON
+    export CF_TESTS=ON
     mkdir build-shared
     cd build-shared
-fi
 
-if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
-    export CMAKE_ARGS="${CMAKE_ARGS} -Dprotobuf_BUILD_TESTS=OFF"
+    if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
+        export CF_TESTS=OFF
+    fi
 fi
 
 cmake -G "Ninja" \
@@ -47,6 +49,7 @@ cmake -G "Ninja" \
     -Dprotobuf_ABSL_PROVIDER="package" \
     -Dprotobuf_BUILD_LIBUPB=ON \
     -Dprotobuf_BUILD_SHARED_LIBS=$CF_SHARED \
+    -Dprotobuf_BUILD_TESTS=$CF_TESTS \
     -Dprotobuf_JSONCPP_PROVIDER="package" \
     -Dprotobuf_USE_EXTERNAL_GTEST=ON \
     -Dprotobuf_WITH_ZLIB=ON \
@@ -54,7 +57,7 @@ cmake -G "Ninja" \
 
 cmake --build .
 
-if [[ "$CONDA_BUILD_CROSS_COMPILATION" != 1 ]]; then
+if [[ "$CF_TESTS" == "ON" ]]; then
     ctest --progress --output-on-failure
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ source:
       - patches/0007-install-a-missing-upb-header.patch
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: libprotobuf


### PR DESCRIPTION
Otherwise we get
```
[942/14629] Linking CXX shared library libgrpc++.1.69.0.dylib
FAILED: libgrpc++.1.69.0.dylib 
: && /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_build_env/bin/x86_64-apple-darwin13.4.0-clang++ -march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0 -isystem /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/include -fdebug-prefix-map=/Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/work=/usr/local/src/conda/libgrpc-1.69.0 -fdebug-prefix-map=/Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol=/usr/local/src/conda-prefix -D_LIBCPP_DISABLE_AVAILABILITY  -O3 -DNDEBUG -isysroot /Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -mmacosx-version-min=10.14 -dynamiclib -Wl,-headerpad_max_install_names -Wl,-headerpad_max_install_names -Wl,-dead_strip_dylibs -Wl,-rpath,/Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib -L/Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib   -compatibility_version 1.69.0 -current_version 1.69.0 -o libgrpc++.1.69.0.dylib -install_name @rpath/libgrpc++.1.69.dylib CMakeFiles/grpc++.dir/src/cpp/client/call_credentials.cc.o CMakeFiles/grpc++.dir/src/cpp/client/channel_cc.cc.o CMakeFiles/grpc++.dir/src/cpp/client/channel_credentials.cc.o CMakeFiles/grpc++.dir/src/cpp/client/client_callback.cc.o CMakeFiles/grpc++.dir/src/cpp/client/client_context.cc.o CMakeFiles/grpc++.dir/src/cpp/client/client_interceptor.cc.o CMakeFiles/grpc++.dir/src/cpp/client/client_stats_interceptor.cc.o CMakeFiles/grpc++.dir/src/cpp/client/create_channel.cc.o CMakeFiles/grpc++.dir/src/cpp/client/create_channel_internal.cc.o CMakeFiles/grpc++.dir/src/cpp/client/create_channel_posix.cc.o CMakeFiles/grpc++.dir/src/cpp/client/global_callback_hook.cc.o CMakeFiles/grpc++.dir/src/cpp/client/insecure_credentials.cc.o CMakeFiles/grpc++.dir/src/cpp/client/secure_credentials.cc.o CMakeFiles/grpc++.dir/src/cpp/client/xds_credentials.cc.o CMakeFiles/grpc++.dir/src/cpp/common/alarm.cc.o CMakeFiles/grpc++.dir/src/cpp/common/auth_property_iterator.cc.o CMakeFiles/grpc++.dir/src/cpp/common/channel_arguments.cc.o CMakeFiles/grpc++.dir/src/cpp/common/completion_queue_cc.cc.o CMakeFiles/grpc++.dir/src/cpp/common/resource_quota_cc.cc.o CMakeFiles/grpc++.dir/src/cpp/common/rpc_method.cc.o CMakeFiles/grpc++.dir/src/cpp/common/secure_auth_context.cc.o CMakeFiles/grpc++.dir/src/cpp/common/secure_create_auth_context.cc.o CMakeFiles/grpc++.dir/src/cpp/common/tls_certificate_provider.cc.o CMakeFiles/grpc++.dir/src/cpp/common/tls_certificate_verifier.cc.o CMakeFiles/grpc++.dir/src/cpp/common/tls_credentials_options.cc.o CMakeFiles/grpc++.dir/src/cpp/common/validate_service_config.cc.o CMakeFiles/grpc++.dir/src/cpp/common/version_cc.cc.o CMakeFiles/grpc++.dir/src/cpp/server/async_generic_service.cc.o CMakeFiles/grpc++.dir/src/cpp/server/backend_metric_recorder.cc.o CMakeFiles/grpc++.dir/src/cpp/server/channel_argument_option.cc.o CMakeFiles/grpc++.dir/src/cpp/server/create_default_thread_pool.cc.o CMakeFiles/grpc++.dir/src/cpp/server/external_connection_acceptor_impl.cc.o CMakeFiles/grpc++.dir/src/cpp/server/health/default_health_check_service.cc.o CMakeFiles/grpc++.dir/src/cpp/server/health/health_check_service.cc.o CMakeFiles/grpc++.dir/src/cpp/server/health/health_check_service_server_builder_option.cc.o CMakeFiles/grpc++.dir/src/cpp/server/insecure_server_credentials.cc.o CMakeFiles/grpc++.dir/src/cpp/server/secure_server_credentials.cc.o CMakeFiles/grpc++.dir/src/cpp/server/server_builder.cc.o CMakeFiles/grpc++.dir/src/cpp/server/server_callback.cc.o CMakeFiles/grpc++.dir/src/cpp/server/server_cc.cc.o CMakeFiles/grpc++.dir/src/cpp/server/server_context.cc.o CMakeFiles/grpc++.dir/src/cpp/server/server_credentials.cc.o CMakeFiles/grpc++.dir/src/cpp/server/server_posix.cc.o CMakeFiles/grpc++.dir/src/cpp/server/xds_server_builder.cc.o CMakeFiles/grpc++.dir/src/cpp/server/xds_server_credentials.cc.o CMakeFiles/grpc++.dir/src/cpp/thread_manager/thread_manager.cc.o CMakeFiles/grpc++.dir/src/cpp/util/byte_buffer_cc.cc.o CMakeFiles/grpc++.dir/src/cpp/util/status.cc.o CMakeFiles/grpc++.dir/src/cpp/util/string_ref.cc.o CMakeFiles/grpc++.dir/src/cpp/util/time_cc.cc.o  -Wl,-rpath,/Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/work/build-cpp  -lm  libgrpc.44.2.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libprotobuf.29.1.0.dylib  libaddress_sorting.44.2.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libssl.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libcrypto.dylib  libgpr.44.2.0.dylib  -lm  -framework CoreFoundation  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_internal_check_op.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_statusor.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_leak_check.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_die_if_null.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_internal_conditions.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_internal_message.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_internal_nullguard.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_examine_stack.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_internal_format.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_internal_proto.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_internal_log_sink_set.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_sink.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_entry.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_flags_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_flags_marshalling.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_flags_reflection.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_flags_config.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_flags_program_name.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_flags_private_handle_accessor.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_flags_commandlineflag.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_flags_commandlineflag_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_initialize.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_internal_globals.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_globals.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_vlog_config_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_internal_fnmatch.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_raw_hash_set.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_hash.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_city.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_low_level_hash.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_hashtablez_sampler.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_random_distributions.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_random_seed_sequences.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_random_internal_pool_urbg.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_random_internal_randen.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_random_internal_randen_hwaes.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_random_internal_randen_hwaes_impl.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_random_internal_randen_slow.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_random_internal_platform.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_random_internal_seed_material.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_random_seed_gen_exception.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_status.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_cord.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_cordz_info.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_cord_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_cordz_functions.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_exponential_biased.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_cordz_handle.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_crc_cord_state.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_crc32c.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_crc_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_crc_cpu_detect.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_bad_optional_access.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_str_format_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_strerror.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_synchronization.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_stacktrace.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_symbolize.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_debugging_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_demangle_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_demangle_rust.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_decode_rust_punycode.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_utf8_for_code_point.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_graphcycles_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_kernel_timeout_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_malloc_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_time.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_civil_time.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_time_zone.2407.0.0.dylib  -Wl,-framework,CoreFoundation  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_bad_variant_access.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_strings.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_int128.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_strings_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_string_view.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_base.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_spinlock_wait.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_throw_delegate.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_raw_logging_internal.2407.0.0.dylib  /Users/runner/miniforge3/conda-bld/grpc-split_1740812980336/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libabsl_log_severity.2407.0.0.dylib && :
Undefined symbols for architecture x86_64:
  "__upb_Arena_SlowMalloc_dont_copy_me__upb_internal_use_only", referenced from:
      grpc::DefaultHealthCheckService::HealthCheckServiceImpl::DecodeRequest(grpc::ByteBuffer const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*) in default_health_check_service.cc.o
      grpc::DefaultHealthCheckService::HealthCheckServiceImpl::EncodeResponse(grpc::DefaultHealthCheckService::ServingStatus, grpc::ByteBuffer*) in default_health_check_service.cc.o
  "_upb_Arena_Free", referenced from:
      grpc::DefaultHealthCheckService::HealthCheckServiceImpl::DecodeRequest(grpc::ByteBuffer const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*) in default_health_check_service.cc.o
      grpc::DefaultHealthCheckService::HealthCheckServiceImpl::EncodeResponse(grpc::DefaultHealthCheckService::ServingStatus, grpc::ByteBuffer*) in default_health_check_service.cc.o
  "_upb_Arena_Init", referenced from:
      grpc::DefaultHealthCheckService::HealthCheckServiceImpl::DecodeRequest(grpc::ByteBuffer const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*) in default_health_check_service.cc.o
      grpc::DefaultHealthCheckService::HealthCheckServiceImpl::EncodeResponse(grpc::DefaultHealthCheckService::ServingStatus, grpc::ByteBuffer*) in default_health_check_service.cc.o
  "_upb_Decode", referenced from:
      grpc::DefaultHealthCheckService::HealthCheckServiceImpl::DecodeRequest(grpc::ByteBuffer const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*) in default_health_check_service.cc.o
  "_upb_Encode", referenced from:
      grpc::DefaultHealthCheckService::HealthCheckServiceImpl::EncodeResponse(grpc::DefaultHealthCheckService::ServingStatus, grpc::ByteBuffer*) in default_health_check_service.cc.o
  "_upb_alloc_global", referenced from:
      grpc::DefaultHealthCheckService::HealthCheckServiceImpl::DecodeRequest(grpc::ByteBuffer const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*) in default_health_check_service.cc.o
      grpc::DefaultHealthCheckService::HealthCheckServiceImpl::EncodeResponse(grpc::DefaultHealthCheckService::ServingStatus, grpc::ByteBuffer*) in default_health_check_service.cc.o
ld: symbol(s) not found for architecture x86_64
```