### PR TITLE
revert commit that broke grpc

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,9 +40,11 @@ source:
       - patches/0006-do-not-add-LIB_PREFIX-to-utf8_-range-validity-on-win.patch     # [win]
       - patches/0007-Workaround-nvcc-bug-in-message_lite.h.patch
       - patches/0008-Ensure-exact-same-retain-attributes-for-UPB-link-tim.patch
+      # Revert https://github.com/protocolbuffers/protobuf/pull/25326
+      - patches/0009-Revert-Breaking-change-make-generator-headers-privat.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libprotobuf

--- a/recipe/patches/0001-set-static-lib-extension-on-windows.patch
+++ b/recipe/patches/0001-set-static-lib-extension-on-windows.patch
@@ -1,14 +1,14 @@
-From f2baa7568fd6de0c39544206f6e3f72d1c884c4e Mon Sep 17 00:00:00 2001
+From a8cd599b8cac8e21163bc55832c473af33c7f3ec Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sun, 4 Sep 2022 10:57:08 +0200
-Subject: [PATCH 1/8] set static lib extension on windows
+Subject: [PATCH 1/9] set static lib extension on windows
 
 ---
  CMakeLists.txt | 6 ++++++
  1 file changed, 6 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3cc06d5..c590e7e 100644
+index f4a4883739..c28d331366 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -314,6 +314,12 @@ else ()

--- a/recipe/patches/0002-always-look-for-shared-abseil-builds.patch
+++ b/recipe/patches/0002-always-look-for-shared-abseil-builds.patch
@@ -1,14 +1,14 @@
-From 4cb68e75d55f4c857c76280c69b1cf303293d7b9 Mon Sep 17 00:00:00 2001
+From 5839e88ff060bdf8da2a3232ba6a17341df160d3 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 13 May 2023 22:43:45 +1100
-Subject: [PATCH 2/8] always look for shared abseil builds
+Subject: [PATCH 2/9] always look for shared abseil builds
 
 ---
  cmake/abseil-cpp.cmake | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/cmake/abseil-cpp.cmake b/cmake/abseil-cpp.cmake
-index 9ef06a2..cee436f 100644
+index 9ef06a23d8..cee436f28d 100644
 --- a/cmake/abseil-cpp.cmake
 +++ b/cmake/abseil-cpp.cmake
 @@ -42,7 +42,7 @@ endif()

--- a/recipe/patches/0003-do-not-install-vendored-gmock.patch
+++ b/recipe/patches/0003-do-not-install-vendored-gmock.patch
@@ -1,14 +1,14 @@
-From 4ff9e40c20d1ab4b3657716c525f9eda407a7b10 Mon Sep 17 00:00:00 2001
+From e4e078547db44ccfa80948fe136895061faa6661 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 9 Aug 2023 14:06:35 +1100
-Subject: [PATCH 3/8] do not install vendored gmock
+Subject: [PATCH 3/9] do not install vendored gmock
 
 ---
  cmake/install.cmake | 7 -------
  1 file changed, 7 deletions(-)
 
 diff --git a/cmake/install.cmake b/cmake/install.cmake
-index 0a31ead..e20ea4e 100644
+index 0a31eade06..e20ea4e32a 100644
 --- a/cmake/install.cmake
 +++ b/cmake/install.cmake
 @@ -183,10 +183,3 @@ if(protobuf_INSTALL_EXAMPLES)

--- a/recipe/patches/0004-disable-MapImplTest.RandomOrdering-due-to-flakiness.patch
+++ b/recipe/patches/0004-disable-MapImplTest.RandomOrdering-due-to-flakiness.patch
@@ -1,7 +1,7 @@
-From a0dbf496a5d2f44e4cc41ff707322a6a38afd8ce Mon Sep 17 00:00:00 2001
+From 412415224f279fb315a4ee79246b349bf17e83f9 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 20 Feb 2024 22:21:55 +1100
-Subject: [PATCH 4/8] disable MapImplTest.RandomOrdering due to flakiness
+Subject: [PATCH 4/9] disable MapImplTest.RandomOrdering due to flakiness
 
 see https://google.github.io/googletest/advanced.html#temporarily-disabling-tests
 ---
@@ -9,7 +9,7 @@ see https://google.github.io/googletest/advanced.html#temporarily-disabling-test
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/google/protobuf/map_test.inc b/src/google/protobuf/map_test.inc
-index e5b5950..51fadd1 100644
+index e5b59509b5..51fadd1068 100644
 --- a/src/google/protobuf/map_test.inc
 +++ b/src/google/protobuf/map_test.inc
 @@ -1434,7 +1434,7 @@ bool MapOrderingIsRandom(int a, int b) {

--- a/recipe/patches/0005-export-symbols-needed-by-grpc.patch
+++ b/recipe/patches/0005-export-symbols-needed-by-grpc.patch
@@ -1,7 +1,7 @@
-From 5cbc6cfae7734bc44a4e3d7ecba75573be923feb Mon Sep 17 00:00:00 2001
+From c9dffd93ce9ff7f0a4107c2d4141288814fcfb30 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sun, 2 Mar 2025 22:14:34 +1100
-Subject: [PATCH 5/8] export symbols needed by grpc
+Subject: [PATCH 5/9] export symbols needed by grpc
 
 avoid that the potentially inlined IsDefaultSerializationDeterministic
 inherits a linker reference to default_serialization_deterministic_, which,
@@ -14,7 +14,7 @@ while part of the .dll/.lib, is private and may not be linkable directly
  4 files changed, 9 insertions(+), 5 deletions(-)
 
 diff --git a/src/google/protobuf/io/coded_stream.cc b/src/google/protobuf/io/coded_stream.cc
-index f10df0b..5072f9c 100644
+index f10df0bb7c..5072f9cd31 100644
 --- a/src/google/protobuf/io/coded_stream.cc
 +++ b/src/google/protobuf/io/coded_stream.cc
 @@ -1023,6 +1023,11 @@ uint8_t* EpsCopyOutputStream::WriteCordOutline(const absl::Cord& c,
@@ -30,7 +30,7 @@ index f10df0b..5072f9c 100644
  
  uint8_t* CodedOutputStream::WriteCordToArray(const absl::Cord& cord,
 diff --git a/src/google/protobuf/io/coded_stream.h b/src/google/protobuf/io/coded_stream.h
-index b68b300..58feee9 100644
+index b68b300fe3..58feee9e22 100644
 --- a/src/google/protobuf/io/coded_stream.h
 +++ b/src/google/protobuf/io/coded_stream.h
 @@ -1315,10 +1315,7 @@ class PROTOBUF_EXPORT PROTOBUF_FUTURE_ADD_EARLY_WARN_UNUSED CodedOutputStream {
@@ -46,7 +46,7 @@ index b68b300..58feee9 100644
    template <typename Func>
    void Serialize(const Func& func);
 diff --git a/upb/mem/alloc.h b/upb/mem/alloc.h
-index 04da233..5f85c69 100644
+index 04da2337b4..5f85c6951d 100644
 --- a/upb/mem/alloc.h
 +++ b/upb/mem/alloc.h
 @@ -76,7 +76,7 @@ UPB_INLINE void upb_free_sized(upb_alloc* alloc, void* ptr, size_t size) {
@@ -59,7 +59,7 @@ index 04da233..5f85c69 100644
  /* Functions that hard-code the global malloc.
   *
 diff --git a/upb/mem/internal/arena.h b/upb/mem/internal/arena.h
-index 1df9785..6e98a0c 100644
+index 1df9785209..6e98a0c0d7 100644
 --- a/upb/mem/internal/arena.h
 +++ b/upb/mem/internal/arena.h
 @@ -70,6 +70,8 @@ UPB_INLINE bool UPB_PRIVATE(_upb_Arena_IsAligned)(const void* ptr) {

--- a/recipe/patches/0006-do-not-add-LIB_PREFIX-to-utf8_-range-validity-on-win.patch
+++ b/recipe/patches/0006-do-not-add-LIB_PREFIX-to-utf8_-range-validity-on-win.patch
@@ -1,14 +1,14 @@
-From e6e288b835753e1abc2e38269f79eedeb6ee3a8a Mon Sep 17 00:00:00 2001
+From d50756b6efe4f96bc3c235912d4e6718bfdd9ce8 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 5 Jul 2025 12:22:19 +1100
-Subject: [PATCH 6/8] do not add LIB_PREFIX to utf8_{range,validity} on windows
+Subject: [PATCH 6/9] do not add LIB_PREFIX to utf8_{range,validity} on windows
 
 ---
  third_party/utf8_range/CMakeLists.txt | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/third_party/utf8_range/CMakeLists.txt b/third_party/utf8_range/CMakeLists.txt
-index 2311970..2313947 100644
+index 231197022a..23139474bb 100644
 --- a/third_party/utf8_range/CMakeLists.txt
 +++ b/third_party/utf8_range/CMakeLists.txt
 @@ -21,11 +21,11 @@ add_library (utf8_validity utf8_range.c)

--- a/recipe/patches/0007-Workaround-nvcc-bug-in-message_lite.h.patch
+++ b/recipe/patches/0007-Workaround-nvcc-bug-in-message_lite.h.patch
@@ -1,7 +1,7 @@
-From 2c2ecc156335d0a389292ff6a5c9d34ec4f78554 Mon Sep 17 00:00:00 2001
+From 1654ab9c668c6815a35f4e06f1b3a14c96e56f1b Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 13 Oct 2025 16:10:25 -0500
-Subject: [PATCH 7/8] Workaround nvcc bug in message_lite.h
+Subject: [PATCH 7/9] Workaround nvcc bug in message_lite.h
 
 See https://github.com/protocolbuffers/protobuf/issues/21542
 
@@ -11,7 +11,7 @@ Patch by Samuel Benzaquen (sbenzaquen)
  1 file changed, 7 insertions(+)
 
 diff --git a/src/google/protobuf/message_lite.h b/src/google/protobuf/message_lite.h
-index c416114..3994762 100644
+index c416114aa9..3994762f06 100644
 --- a/src/google/protobuf/message_lite.h
 +++ b/src/google/protobuf/message_lite.h
 @@ -273,6 +273,12 @@ struct MessageTraitsImpl {

--- a/recipe/patches/0008-Ensure-exact-same-retain-attributes-for-UPB-link-tim.patch
+++ b/recipe/patches/0008-Ensure-exact-same-retain-attributes-for-UPB-link-tim.patch
@@ -1,7 +1,7 @@
-From c2230be610cd6319f9210da654cedff504fcd910 Mon Sep 17 00:00:00 2001
+From b1f19d13d00fcf64e6440322b0a99fb1072f4683 Mon Sep 17 00:00:00 2001
 From: Julien Jerphanion <git@jjerphan.xyz>
 Date: Fri, 27 Feb 2026 11:09:59 +0100
-Subject: [PATCH 8/8] Ensure exact same retain attributes for UPB link-time
+Subject: [PATCH 8/9] Ensure exact same retain attributes for UPB link-time
  entries
 
 Ensure the UPB link-time array entries have the same retain attributes
@@ -13,7 +13,7 @@ Signed-off-by: Julien Jerphanion <git@jjerphan.xyz>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/upb/port/def.inc b/upb/port/def.inc
-index 4616c65..7c1276c 100644
+index b398a95a55..0b128faa9f 100644
 --- a/upb/port/def.inc
 +++ b/upb/port/def.inc
 @@ -577,7 +577,7 @@ Error, UINTPTR_MAX is undefined

--- a/recipe/patches/0009-Revert-Breaking-change-make-generator-headers-privat.patch
+++ b/recipe/patches/0009-Revert-Breaking-change-make-generator-headers-privat.patch
@@ -1,0 +1,299 @@
+From f8f13c84c348db1dc005a39df3220607cc19f1c3 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Sat, 13 Jun 2026 14:03:08 +1100
+Subject: [PATCH 9/9] Revert "Breaking change: make generator headers private"
+
+Reverts https://github.com/protocolbuffers/protobuf/pull/25326 + follow-up,
+which breaks grpc, see https://github.com/grpc/grpc/issues/41755
+
+This reverts commit 3a2af3510f0d454dbe3e4dc281674b61c4d20b9e.
+
+This reverts commit 601bdf741d7f7ff8798c0193b1c1d298e9787117.
+---
+ cmake/installed_include_golden.txt            |  8 ++++++++
+ pkg/BUILD.bazel                               |  9 +++++++++
+ src/file_lists.cmake                          |  9 +++++++++
+ src/google/protobuf/compiler/cpp/BUILD.bazel  | 14 +++++++++++++
+ .../protobuf/compiler/csharp/BUILD.bazel      | 12 +++++++++++
+ src/google/protobuf/compiler/java/BUILD.bazel | 12 +++++++++++
+ .../protobuf/compiler/kotlin/BUILD.bazel      | 12 +++++++++++
+ .../protobuf/compiler/objectivec/BUILD.bazel  | 12 +++++++++++
+ .../protobuf/compiler/python/BUILD.bazel      | 20 +++++++++++++++++++
+ src/google/protobuf/compiler/ruby/BUILD.bazel | 12 +++++++++++
+ 10 files changed, 120 insertions(+)
+
+diff --git a/cmake/installed_include_golden.txt b/cmake/installed_include_golden.txt
+index 2f2e90414f..fda1b5ccdf 100644
+--- a/cmake/installed_include_golden.txt
++++ b/cmake/installed_include_golden.txt
+@@ -13,9 +13,11 @@ google/protobuf/c_sharp_features.proto
+ google/protobuf/compiler/code_generator.h
+ google/protobuf/compiler/code_generator_lite.h
+ google/protobuf/compiler/command_line_interface.h
++google/protobuf/compiler/cpp/generator.h
+ google/protobuf/compiler/cpp/helpers.h
+ google/protobuf/compiler/cpp/names.h
+ google/protobuf/compiler/cpp/options.h
++google/protobuf/compiler/csharp/csharp_generator.h
+ google/protobuf/compiler/csharp/names.h
+ google/protobuf/compiler/importer.h
+ google/protobuf/compiler/java/doc_comment.h
+@@ -25,16 +27,22 @@ google/protobuf/compiler/java/java_features.pb.h
+ google/protobuf/compiler/java/name_resolver.h
+ google/protobuf/compiler/java/names.h
+ google/protobuf/compiler/java/options.h
++google/protobuf/compiler/kotlin/generator.h
+ google/protobuf/compiler/notices.h
++google/protobuf/compiler/objectivec/generator.h
+ google/protobuf/compiler/objectivec/line_consumer.h
+ google/protobuf/compiler/objectivec/names.h
+ google/protobuf/compiler/objectivec/nsobject_methods.h
+ google/protobuf/compiler/parser.h
+ google/protobuf/compiler/php/names.h
++google/protobuf/compiler/php/php_generator.h
+ google/protobuf/compiler/plugin.h
+ google/protobuf/compiler/plugin.pb.h
+ google/protobuf/compiler/plugin.proto
++google/protobuf/compiler/python/generator.h
++google/protobuf/compiler/python/pyi_generator.h
+ google/protobuf/compiler/retention.h
++google/protobuf/compiler/ruby/ruby_generator.h
+ google/protobuf/compiler/scc.h
+ google/protobuf/compiler/subprocess.h
+ google/protobuf/compiler/versions.h
+diff --git a/pkg/BUILD.bazel b/pkg/BUILD.bazel
+index 00a5da334e..9ad8ae19f2 100644
+--- a/pkg/BUILD.bazel
++++ b/pkg/BUILD.bazel
+@@ -231,6 +231,15 @@ cc_dist_library(
+         "//src/google/protobuf/compiler/java:names",
+         "//src/google/protobuf/compiler/objectivec:names",
+         "//src/google/protobuf/compiler/php:names",
++        # TODO Make these private in the next breaking C++ release.
++        "//src/google/protobuf/compiler/cpp:generator_headers",
++        "//src/google/protobuf/compiler/csharp:generator_headers",
++        "//src/google/protobuf/compiler/java:generator_headers",
++        "//src/google/protobuf/compiler/kotlin:generator_headers",
++        "//src/google/protobuf/compiler/objectivec:generator_headers",
++        "//src/google/protobuf/compiler/php:php_generator",
++        "//src/google/protobuf/compiler/python:generator_headers",
++        "//src/google/protobuf/compiler/ruby:generator_headers",
+     ],
+ )
+ 
+diff --git a/src/file_lists.cmake b/src/file_lists.cmake
+index c951089818..fe2f48c66f 100644
+--- a/src/file_lists.cmake
++++ b/src/file_lists.cmake
+@@ -321,6 +321,7 @@ set(libprotoc_public_srcs
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/objectivec/line_consumer.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/objectivec/names.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/php/names.cc
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/php/php_generator.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/plugin.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/plugin.pb.cc
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/retention.cc
+@@ -334,9 +335,11 @@ set(libprotoc_public_hdrs
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/code_generator.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/code_generator_lite.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/command_line_interface.h
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/cpp/generator.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/cpp/helpers.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/cpp/names.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/cpp/options.h
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/csharp/csharp_generator.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/csharp/names.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/java/doc_comment.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/java/generator.h
+@@ -346,14 +349,20 @@ set(libprotoc_public_hdrs
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/java/names.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/java/names_internal.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/java/options.h
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/kotlin/generator.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/notices.h
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/objectivec/generator.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/objectivec/line_consumer.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/objectivec/names.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/objectivec/nsobject_methods.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/php/names.h
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/php/php_generator.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/plugin.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/plugin.pb.h
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/python/generator.h
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/python/pyi_generator.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/retention.h
++  ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/ruby/ruby_generator.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/scc.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/subprocess.h
+   ${protobuf_SOURCE_DIR}/src/google/protobuf/compiler/versions.h
+diff --git a/src/google/protobuf/compiler/cpp/BUILD.bazel b/src/google/protobuf/compiler/cpp/BUILD.bazel
+index 70666024cc..4235623984 100644
+--- a/src/google/protobuf/compiler/cpp/BUILD.bazel
++++ b/src/google/protobuf/compiler/cpp/BUILD.bazel
+@@ -32,6 +32,20 @@ cc_library(
+     ],
+ )
+ 
++cc_library(
++    name = "generator_headers",
++    hdrs = ["generator.h"],
++    copts = COPTS,
++    strip_include_prefix = "/src",
++    visibility = ["//pkg:__pkg__"],
++    deps = [
++        "//src/google/protobuf",
++        "//src/google/protobuf/compiler:code_generator",
++        "@abseil-cpp//absl/status",
++        "@abseil-cpp//absl/strings",
++    ],
++)
++
+ cc_library(
+     name = "names_internal",
+     srcs = [
+diff --git a/src/google/protobuf/compiler/csharp/BUILD.bazel b/src/google/protobuf/compiler/csharp/BUILD.bazel
+index 6bb9d6a327..53425d18b6 100644
+--- a/src/google/protobuf/compiler/csharp/BUILD.bazel
++++ b/src/google/protobuf/compiler/csharp/BUILD.bazel
+@@ -20,6 +20,18 @@ cc_library(
+     ],
+ )
+ 
++cc_library(
++    name = "generator_headers",
++    hdrs = ["csharp_generator.h"],
++    copts = COPTS,
++    strip_include_prefix = "/src",
++    visibility = ["//pkg:__pkg__"],
++    deps = [
++        "//src/google/protobuf",
++        "//src/google/protobuf/compiler:code_generator",
++    ],
++)
++
+ cc_library(
+     name = "csharp",
+     srcs = [
+diff --git a/src/google/protobuf/compiler/java/BUILD.bazel b/src/google/protobuf/compiler/java/BUILD.bazel
+index b3c738e2af..2419b40309 100644
+--- a/src/google/protobuf/compiler/java/BUILD.bazel
++++ b/src/google/protobuf/compiler/java/BUILD.bazel
+@@ -33,6 +33,18 @@ cc_library(
+     ],
+ )
+ 
++cc_library(
++    name = "generator_headers",
++    hdrs = ["generator.h"],
++    copts = COPTS,
++    strip_include_prefix = "/src",
++    visibility = ["//pkg:__pkg__"],
++    deps = [
++        "//src/google/protobuf",
++        "//src/google/protobuf/compiler:code_generator",
++    ],
++)
++
+ cc_library(
+     name = "context",
+     hdrs = [
+diff --git a/src/google/protobuf/compiler/kotlin/BUILD.bazel b/src/google/protobuf/compiler/kotlin/BUILD.bazel
+index c824f3c22a..5a1e1b7270 100644
+--- a/src/google/protobuf/compiler/kotlin/BUILD.bazel
++++ b/src/google/protobuf/compiler/kotlin/BUILD.bazel
+@@ -1,6 +1,18 @@
+ load("@rules_cc//cc:cc_library.bzl", "cc_library")
+ load("//build_defs:cpp_opts.bzl", "COPTS")
+ 
++cc_library(
++    name = "generator_headers",
++    hdrs = ["generator.h"],
++    copts = COPTS,
++    strip_include_prefix = "/src",
++    visibility = ["//pkg:__pkg__"],
++    deps = [
++        "//src/google/protobuf",
++        "//src/google/protobuf/compiler:code_generator",
++    ],
++)
++
+ cc_library(
+     name = "kotlin",
+     srcs = ["generator.cc"],
+diff --git a/src/google/protobuf/compiler/objectivec/BUILD.bazel b/src/google/protobuf/compiler/objectivec/BUILD.bazel
+index 732d461a8d..4945c0255c 100644
+--- a/src/google/protobuf/compiler/objectivec/BUILD.bazel
++++ b/src/google/protobuf/compiler/objectivec/BUILD.bazel
+@@ -17,6 +17,18 @@ cc_library(
+     ],
+ )
+ 
++cc_library(
++    name = "generator_headers",
++    hdrs = ["generator.h"],
++    copts = COPTS,
++    strip_include_prefix = "/src",
++    visibility = ["//pkg:__pkg__"],
++    deps = [
++        "//src/google/protobuf",
++        "//src/google/protobuf/compiler:code_generator",
++    ],
++)
++
+ cc_library(
+     name = "names_internal",
+     srcs = [
+diff --git a/src/google/protobuf/compiler/python/BUILD.bazel b/src/google/protobuf/compiler/python/BUILD.bazel
+index ec6e73121c..6a8de76d7a 100644
+--- a/src/google/protobuf/compiler/python/BUILD.bazel
++++ b/src/google/protobuf/compiler/python/BUILD.bazel
+@@ -6,6 +6,26 @@ load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+ load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
+ load("//build_defs:cpp_opts.bzl", "COPTS")
+ 
++cc_library(
++    name = "generator_headers",
++    hdrs = [
++        "generator.h",
++        "pyi_generator.h",
++    ],
++    copts = COPTS,
++    strip_include_prefix = "/src",
++    visibility = ["//pkg:__pkg__"],
++    deps = [
++        "//src/google/protobuf",
++        "//src/google/protobuf/compiler:code_generator",
++        "@abseil-cpp//absl/container:flat_hash_map",
++        "@abseil-cpp//absl/container:flat_hash_set",
++        "@abseil-cpp//absl/memory",
++        "@abseil-cpp//absl/strings",
++        "@abseil-cpp//absl/synchronization",
++    ],
++)
++
+ cc_library(
+     name = "python",
+     srcs = [
+diff --git a/src/google/protobuf/compiler/ruby/BUILD.bazel b/src/google/protobuf/compiler/ruby/BUILD.bazel
+index eff47f0fee..27b4fb844b 100644
+--- a/src/google/protobuf/compiler/ruby/BUILD.bazel
++++ b/src/google/protobuf/compiler/ruby/BUILD.bazel
+@@ -6,6 +6,18 @@ load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+ load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
+ load("//build_defs:cpp_opts.bzl", "COPTS")
+ 
++cc_library(
++    name = "generator_headers",
++    hdrs = ["ruby_generator.h"],
++    copts = COPTS,
++    strip_include_prefix = "/src",
++    visibility = ["//pkg:__pkg__"],
++    deps = [
++        "//src/google/protobuf",
++        "//src/google/protobuf/compiler:code_generator",
++    ],
++)
++
+ cc_library(
+     name = "ruby",
+     srcs = [


### PR DESCRIPTION
Revert https://github.com/protocolbuffers/protobuf/pull/25326 due to https://github.com/grpc/grpc/issues/41755

This is not a sustainable longterm solution, but use this to unblock things now, while grpc figures out how to deal with this.